### PR TITLE
Adding the installation page and Updating the getting started dependencies formatting

### DIFF
--- a/panel/getting_started.md
+++ b/panel/getting_started.md
@@ -26,14 +26,25 @@ this software on an OpenVZ based system you will not be successful.
 | | 9 | :white_check_mark: | |
 
 ## Dependencies
-* PHP `7.2` with the following extensions: `cli`, `openssl`, `gd`, `mysql`, `PDO`, `mbstring`, `tokenizer`, `bcmath`, `xml` or `dom`, `curl`, `zip`
-* MySQL `5.7` or higher **or** MariaDB `10.1.3` or higher
+* PHP `7.2` with the following extensions: 
+    * CLI `php7.2-cli`
+    * `openssl` (included with packaged versions)) 
+    * GD `php7.2-gd`
+    * MySQL `php7.2-mysql`
+    * PDO `php7.2-pdo`
+    * MBString `php7.2-mbstring`
+    * Tokenizer `php7.2-tokenizer` 
+    * BCMath `php7.2-bcmath` 
+    * DOM `php7.2-xml` or `php7.2-dom`
+    * cURL `php7.2-curl`
+    * Zip `php7.2-zip`
+* MySQL `>= 5.7` **or** MariaDB `>= 10.1.3`
 * Redis (`redis-server`)
-* A webserver (Apache, NGINX, Caddy, etc.)
-* `curl`
-* `tar`
-* `unzip`
-* `git`
+* A web server (e.g Apache, NGINX, Caddy, etc.) 
+* cURL `curl`
+* Tar `tar`
+* Unzip `unzip`
+* Git `git`
 
 ### Example Dependency Installation
 The commands below are simply an example of how you might install these dependencies. Please consult with your

--- a/panel/installation.md
+++ b/panel/installation.md
@@ -1,0 +1,106 @@
+# Installation
+This section covers how to install the panel once all of the dependencies have been met and the panel 
+files have been downloaded.
+
+## Composer
+Pterodactyl Panel makes use of [Composer](https://getcomposer.org/) to install dependencies and get everything setup
+and running for you. In order to use composer, you wil first need to install it.
+
+```
+curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer
+```
+
+## Database Configuration
+Pterodactyl Panel will automatically configure your database for you. You will need to have connection details on hand, 
+as well as create __an empty database__ for the panel to install to.
+
+## Setup
+Once you have composer installed you only need to run one command to have 
+the panel run through the installation and setup process.
+
+```
+cp .env.example .env
+composer install --no-dev
+```
+
+When you run the command above it will begin by installing all of the dependencies required by the panel into 
+the `vendor/` directory.
+
+We then need to generate an application encryption key using the command below. 
+_You should only run this command once when installing the Panel._
+
+```
+php artisan key:generate --force
+```
+
+::: danger Stop!
+The key you generated with the above command should never be disclosed to others, and you should store a secure copy of 
+that key off-site in a secure manner. If you ever need to reinstall the Panel or migrate to a new server you will need 
+to continue using this key to avoid losing encrypted information in the database.
+:::
+
+## Environment Configuration
+::: tip MySQL Database
+__You will need an existing MySQL database__ and non-root user to continue with the installation. 
+Please see our [Setting Up MySQL](https://pterodactyl.io/docs/setting-up-mysql) tutorial for how to do this 
+if you are unsure.
+:::
+
+The next thing we need to do is get our environment setup for the panel. 
+To do this, run the commands below and follow the prompts.
+
+```
+php artisan p:environment:setup
+php artisan p:environment:database
+```
+
+After you've configured the environment, we need to configure email handling. To do that, enter the command below and 
+follow the prompts. If you would like to use PHP's mail() function simply select the mail option. You also have the 
+option to use SMTP or an email delivery service.
+
+```
+php artisan p:environment:mail
+```
+
+## Database Setup
+We can now setup the database. This is an automatic process that only requires you enter the command below.
+
+```
+php artisan migrate
+```
+
+::: tip
+This command will ask if you are sure you want to continue on a live environment, tell it yes.
+:::
+
+Once the database is setup we then need to seed the database with nest information. To do so, run the command below.
+
+```
+php artisan db:seed
+```
+
+## Add Admin Account
+Finally, we need to create an admin account on the system. Run the command below and follow the prompts to do so.
+
+```
+php artisan p:user:make
+```
+
+::: warning
+Passwords for the user must include mixed case, at least one number, and at least 8 characters. 
+The script will fail otherwise.
+:::
+
+## Set Permissions
+The last step here is to set the proper owner of the files to be the user that runs your web server. 
+In most cases this is `www-data` but can vary from system to system — sometimes being `nobody` or `apache`.
+
+``` 
+chown -R www-data:www-data *
+
+# If using CentOS NGINX do:
+chown -R nginx:nginx *
+
+# If using CentOS Apache do:
+chown -R apache:apache *
+```


### PR DESCRIPTION
This PR adds the installation documentation page, which is a direct copy of the [Installing](https://pterodactyl.readme.io/docs/installing-1) page.
I also felt like the formatting of the php-modules was hard to read, so I formatted it like it was on the readme.io doc page.
