### PR TITLE
Update creating_ssl_certificates.md

### DIFF
--- a/tutorials/creating_ssl_certificates.md
+++ b/tutorials/creating_ssl_certificates.md
@@ -30,5 +30,7 @@ You can add the command below to that crontab. For advanced users, we suggest in
 which provides more options, and is much more powerful than certbot.
 
 ``` text
+service nginx stop
 letsencrypt renew
+service nginx start
 ```


### PR DESCRIPTION
When NGINX is active letsencrypt won't work, unless we used the --nginx tag when creating the certificate. With this NGINX will be disabled when creating the certificate.