### PR TITLE
Add further explanation for Gmail SMTP

### DIFF
--- a/panel/getting_started.md
+++ b/panel/getting_started.md
@@ -111,6 +111,10 @@ php artisan key:generate --force
 ### Environment Configuration
 Pterodactyl's core environment is easily configured using a few different CLI commands built into the app. This step
 will cover setting up things such as sessions, caching, database credentials, and email sending.
+::: tip Using Google's SMTP host
+If using Gmails free SMTP host, follow the guide in the Tutorials section to utilise it correctly
+without encountering issues.
+:::
 
 ``` bash
 php artisan p:environment:setup

--- a/panel/troubleshooting.md
+++ b/panel/troubleshooting.md
@@ -100,7 +100,7 @@ the Daemon's ports from the outside network are setup.
 
 * If nothing is working so far, check your own DNS settings and consider switching DNS servers.
 
-* When running the Panel and Daemon on one server it can sometimes help if to add an entry in `/etc/hosts` that directs
+* When running the Panel and Daemon on one server it can sometimes help to add an entry in `/etc/hosts` that directs
 the public IP back to the server. Sometimes the reverse path is also needed, so you may need to add an entry to your
 servers `/etc/hosts` file that points the Panel's domain to the correct IP.
 

--- a/tutorials/using_gmail_smtp.md
+++ b/tutorials/using_gmail_smtp.md
@@ -1,0 +1,29 @@
+# Using Google's SMTP server
+[[toc]]
+
+During the panel installation you are required to select and setup a mail server. Google provides a free to use SMTP
+server. This is a simple guide on how to utilise this service and cover basics of the functions of it.
+
+## Enabling 2FA
+To obtain an app password required for SMTP, the Gmail account being used must have 2-step-authentication enabled for security reasons.
+You can enable this on [this site.](https://www.google.com/landing/2step/)
+
+## Generating the app password
+Once 2FA is enabled, you need to generate an app password [here](https://security.google.com/settings/security/apppasswords).
+Take a note of this as it will be needed later, but **DO NOT SHARE THIS**.
+
+## Continuing in the setup
+Use this command to trigger the mail server setup:
+```php artisan p:environment:mail```
+
+Use SMTP, and enter `smtp.google.com` for the SMTP host. Use port 465. When prompted to enter a username, enter the Gmail email you
+used to create an app password. Then, enter the app password but **do not use your gmail login password**
+When given a prompt to enter the email address emails should originate from, you can either enter your Gmail email or use your own
+email account on your own domain, but this must be added to your Gmail account. (You can add an address by going to Settings,
+Accounts and Import, and adding it in there)
+Set the name that emails should appear from to whatever you want to show in users inboxes and chose SSL for the encryption method.
+
+## Applying changes
+
+To apply these changes, run this command.
+```service pteroq restart```


### PR DESCRIPTION
Added info about how to use Gmail's SMTP host in Ptero correctly, thought it might go well in the tutorials section.