### PR TITLE
Fixing documentation error

### DIFF
--- a/tutorials/creating_ssl_certificates.md
+++ b/tutorials/creating_ssl_certificates.md
@@ -6,8 +6,8 @@ site](https://certbot.eff.org/) for installation instructions.
                                                                                                                
 ``` bash
 sudo add-apt-repository ppa:certbot/certbot
-sudo apt-get update
-sudo apt-get install certbot
+sudo apt update
+sudo apt install certbot
 ```
 
 ## Creating a Certificate


### PR DESCRIPTION
Seeing as the rest of the documentation revolves around the usage of apt instead of apt-get the SSL certificate bit should as well.