### PR TITLE
Fix typo (0.6.S to 0.6.X)

### DIFF
--- a/daemon/upgrading.md
+++ b/daemon/upgrading.md
@@ -3,5 +3,5 @@
 ## Version Specific Guides
 * [0.4.X to 0.5.X](upgrade/0.4_to_0.5.md)
 * [0.5.X series](upgrade/0.5.md)
-* [0.5.X to 0.6.S](upgrade/0.5_to_0.6.md) <Badge text="current" vertical="middle"/>
+* [0.5.X to 0.6.X](upgrade/0.5_to_0.6.md) <Badge text="current" vertical="middle"/>
 * [0.6.X series](upgrade/0.6.md) <Badge text="current" vertical="middle"/>


### PR DESCRIPTION
I just fixed a typo on the "Upgrading" page for the daemon.