### PR TITLE
Errors

### DIFF
--- a/panel/upgrade/0.6_to_0.7.md
+++ b/panel/upgrade/0.6_to_0.7.md
@@ -38,6 +38,14 @@ templates.
 php artisan view:clear
 ```
 
+If this throws a LaravelTheme error, you may need to update dependencies by using Composer.
+
+``` bash
+composer install --no-dev --optimize-autoloader
+```
+
+Then, go back to clear the configuration cache.
+
 ## Update Dependencies
 After you've downloaded all of the new files you will need to upgrade the core components of the panel. To do this,
 simply run the commands below and follow any prompts.


### PR DESCRIPTION
Some people experience an error where they cannot clear their template cache because some dependencies were out-of-date.