### PR TITLE
Update service name and fix spelling in community section

### DIFF
--- a/community/install/panel/centos7.md
+++ b/community/install/panel/centos7.md
@@ -78,7 +78,7 @@ yum install -y certbot
 curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ```
 
-## Server Configuriation
+## Server Configuration
 
 This following section covers the configuration of parts of the server to run the panel.
 

--- a/community/install/panel/debian9.md
+++ b/community/install/panel/debian9.md
@@ -113,8 +113,8 @@ The default php-fpm configuration is good to use.
 
 Start and enable php-fpm on the system.
 ```bash
-systemctl enable php-fpm
-systemctl start php-fpm
+systemctl enable php7.2-fpm
+systemctl start php7.2-fpm
 ```
 
 ### nginx

--- a/community/install/panel/debian9.md
+++ b/community/install/panel/debian9.md
@@ -72,7 +72,7 @@ apt install -y certbot curl
 curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ```
 
-## Server Configuriation
+## Server Configuration
 
 This following section covers the configuration of parts of the server to run the panel.
 

--- a/community/install/panel/ubuntu1804.md
+++ b/community/install/panel/ubuntu1804.md
@@ -100,8 +100,8 @@ The default php-fpm configuration is good to use.
 
 Start and enable php-fpm on the system.
 ```bash
-systemctl enable php-fpm
-systemctl start php-fpm
+systemctl enable php7.2-fpm
+systemctl start php7.2-fpm
 ```
 
 ### nginx


### PR DESCRIPTION
corrected the php7.2-fpm service for ubuntu and debian

fixed spelling for "configuration" for centos and debian