### PR TITLE
Update CentOS 7 tutorial

### DIFF
--- a/community/install/panel/centos7.md
+++ b/community/install/panel/centos7.md
@@ -115,9 +115,8 @@ We have a tutorial in the tutorial section
 
 ### PHP
 
-The default php-fpm configuration is good to use but you need to edit the nginx config to use the ip address.
-
 The following config is the one that will match the nginx config later in the guide.
+Place the contents below in a file called `www-pterodactyl.conf` in the `/etc/php-fpm.d` folder.
 
 <<< @/.snippets/php-fpm/pterodactyl-centos.conf
 

--- a/community/install/panel/centos7.md
+++ b/community/install/panel/centos7.md
@@ -115,8 +115,7 @@ We have a tutorial in the tutorial section
 
 ### PHP
 
-The following config is the one that will match the nginx config later in the guide.
-Place the contents below in a file called `www-pterodactyl.conf` in the `/etc/php-fpm.d` folder.
+Place the contents below in a file inside the `/etc/php-fpm.d` folder. The file can be named anything, but a good standard is `www-pterodactyl.conf`. This config will match the nginx config later in the guide.
 
 <<< @/.snippets/php-fpm/pterodactyl-centos.conf
 


### PR DESCRIPTION
The instructions about where the contents described should be placed were not clear, leading to error 403 at the end of the installation.