### PR TITLE
Added documentation for acme.sh

### DIFF
--- a/tutorials/creating_ssl_certificates.md
+++ b/tutorials/creating_ssl_certificates.md
@@ -1,6 +1,8 @@
 # Creating SSL Certificates
-This tutorial briefly covers creating new SSL certificates for your panel and daemon using LetsEncrypt&trade;. To
-begin, we will be installing certbot, a simple script that will automatically renew our certificates and allow much
+This tutorial briefly covers creating new SSL certificates for your panel and daemon using LetsEncrypt&trade;. 
+
+## Method 1: Using Certbot
+To begin, we will be installing certbot, a simple script that will automatically renew our certificates and allow much
 cleaner creation of them. The command below is for Ubuntu distributions, but you can always check [Certbot's official
 site](https://certbot.eff.org/) for installation instructions.
                                                                                                                
@@ -10,7 +12,7 @@ sudo apt update
 sudo apt install certbot
 ```
 
-## Creating a Certificate
+### Creating a Certificate
 After installing certbot, we need to then generate a certificate. There are a couple ways to do that, but the
 easiest is to have letsencrypt spin-up a temporary web-server to do this. In order for this to work, you will
 first need to stop NGINX or Apache.
@@ -26,11 +28,48 @@ that you've already configured the webservers to use SSL).
 certbot certonly -d example.com
 ```
 
-## Auto Renewal
+### Auto Renewal
 You'll also probably want to configure automatic renewal by adding the command below to a cronjob that runs daily.
 You can add the command below to that crontab. For advanced users, we suggest installing and using [acme.sh](https://acme.sh)
-which provides more options, and is much more powerful than certbot.
+which provides more options (see below), and is much more powerful than certbot.
 
 ``` text
 certbot renew
+```
+
+## Method 2: Using acme.sh
+This is for advanced users, of which their server systems do not have access to port 80. The command below is for Ubuntu distributions and CloudFlare API (you may google for other APIs for other DNS providers), but you can always check [acme.sh's official site](https://github.com/Neilpang/acme.sh) for installation instructions.
+
+``` bash
+curl https://get.acme.sh | sh
+```
+
+### Obtaining CloudFlare API Key
+After installing acme.sh, we need to fetch a CloudFlare API key. Please make sure that a DNS record (A or CNAME record) is pointing to your target node, and set the cloud to grey (bypassing CloudFlare proxy). Then go to My Profile > API keys and on Glocal API Key subtab, click on "view", enter your CloudFlare password, and copy the API key to clipboard.
+
+### Creating a Certificate
+Since the configuration file is based on Certbot, we need to create the folder manually.
+
+```bash
+sudo mkdir /etc/letsencrypt/live/example.com
+```
+
+After installing certbot and obtaining CloudFlare API key, we need to then generate a certificate. First input the CloudFlare API credentials.
+
+```bash
+export CF_Key="Your_CloudFlare_API_Key"
+export CF_Email="Your_CloudFlare_Account@example.com"
+```
+Then create the certificate.
+
+```bash
+acme.sh --issue --standalone -d "example.com" --dns dns_cf \
+--key-file /etc/letsencrypt/live/example.com/privkey.pem \
+--fullchain-file /etc/letsencrypt/live/example.com/fullchain.pem 
+```
+### Auto Renewal
+After running the script for the first time, it will be added to the crontab automatically. You may edit the auto renewal interval by editing the crontab.
+
+```bash
+sudo crontab -e
 ```


### PR DESCRIPTION
Making use of APIs of DNS providers, auto-renewal can be done even port 80 is not available on the node to the internet.