### PR TITLE
Start redis server on boot

### DIFF
--- a/panel/getting_started.md
+++ b/panel/getting_started.md
@@ -211,6 +211,13 @@ If you are not using `redis` for anything you should remove the `After=` line, o
 when the service starts.
 :::
 
+:::
+If you are are using redis for your system, you will want to make sure to enable that it will start on boot. You can do that by running the following command: 
+```bash
+sudo systemctl enable redis-server
+```
+:::
+
 Finally, enable the service and set it to boot on machine start.
 
 ``` bash


### PR DESCRIPTION
Unless I missed it, I did not see any documentation on telling the user to enable this server. Typically if someone doesn't know they should do this, then they most likely won't. Failing to run this command has caused a lot of unneeded issues due to the panel not being able to fetch the eggs since the redis-server isn't running.