### PR TITLE
Add python-dev packages

### DIFF
--- a/community/installation-guides/daemon/debian9.md
+++ b/community/installation-guides/daemon/debian9.md
@@ -13,7 +13,7 @@ We will first begin by installing all of the Daemon's [required](/daemon/install
 
 ### General Requirements
 ```bash
-apt install -y zip unzip tar make gcc g++ python curl gnupg
+apt install -y zip unzip tar make gcc g++ python python-dev curl gnupg
 ```
 
 ### Docker

--- a/daemon/installing.md
+++ b/daemon/installing.md
@@ -51,7 +51,7 @@ Pterodactyl's Daemon requires the following dependencies be installed on your sy
 * `tar`
 * `unzip`
 * `make`, `gcc` (`gcc-c++` on CentOS), `g++`
-* `python`, `python-dev`
+* `python`
 
 ### Installing Docker
 For a quick install of Docker CE, you can execute the command below:
@@ -100,7 +100,7 @@ NodeJS is also super easy to install! Simply run the command below to make the p
 
 ``` bash
 curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-apt -y install nodejs make gcc g++ python-dev
+apt -y install nodejs make gcc g++
 ```
 
 ::: tip Other OS Distributions

--- a/daemon/installing.md
+++ b/daemon/installing.md
@@ -51,7 +51,7 @@ Pterodactyl's Daemon requires the following dependencies be installed on your sy
 * `tar`
 * `unzip`
 * `make`, `gcc` (`gcc-c++` on CentOS), `g++`
-* `python`
+* `python`, `python-dev`
 
 ### Installing Docker
 For a quick install of Docker CE, you can execute the command below:
@@ -100,7 +100,7 @@ NodeJS is also super easy to install! Simply run the command below to make the p
 
 ``` bash
 curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-apt -y install nodejs make gcc g++
+apt -y install nodejs make gcc g++ python-dev
 ```
 
 ::: tip Other OS Distributions


### PR DESCRIPTION
mmmagic fails to build without python-dev installed on Debian 9. It's not installed by default on OVH atleast.