### PR TITLE
Clarify something for Apache

### DIFF
--- a/panel/getting_started.md
+++ b/panel/getting_started.md
@@ -211,12 +211,10 @@ If you are not using `redis` for anything you should remove the `After=` line, o
 when the service starts.
 :::
 
-:::
 If you are are using redis for your system, you will want to make sure to enable that it will start on boot. You can do that by running the following command: 
 ```bash
 sudo systemctl enable redis-server
 ```
-:::
 
 Finally, enable the service and set it to boot on machine start.
 

--- a/panel/webserver_configuration.md
+++ b/panel/webserver_configuration.md
@@ -38,6 +38,8 @@ systemctl restart nginx
 You should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
 `pterodactyl.conf` and place it in `/etc/apache2/sites-available`, or &mdash; if on CentOS, `/etc/httpd/conf.d/`.
 
+Note: When using Apache, make sure you have the `libapache2-mod-php` package installed or else PHP will not display on your webserver.
+
 ### Apache With SSL
 Like the nginx configuration, this assumes you will be using SSL on both the Panel and Daemons for improved security. You will need to visit our [Creating SSL Certificates](/tutorials/creating_ssl_certificates.html) documentation page on how to create these certificates.
 


### PR DESCRIPTION
It seems to be a weekly issue that for people with Apache, they have issues installing the panel because they follow the tutorial and then when they view it, it's displaying the actual PHP code. The notice I've inserted will help make users aware that when using Apache, they need to specific package for Apache that will make PHP run properly.