### PR TITLE
Use the official script instead of docker.io

### DIFF
--- a/community/installation-guides/daemon/ubuntu1804.md
+++ b/community/installation-guides/daemon/ubuntu1804.md
@@ -19,7 +19,7 @@ apt install -y zip unzip tar make gcc g++ python
 ### Docker
 
 ```bash
-apt install -y docker.io
+curl -sSL https://get.docker.com/ | CHANNEL=stable bash
 
 systemctl enable docker
 systemctl start docker


### PR DESCRIPTION
Ubuntu 18.04 has been supported by docker for a while now, using the official script will give an up to date version of docker and is also more consistent with the official docs.