### PR TITLE
Add unzip to fix composer for centos

### DIFF
--- a/community/installation-guides/panel/centos7.md
+++ b/community/installation-guides/panel/centos7.md
@@ -68,11 +68,6 @@ systemctl enable redis
 
 ### Additional Utilities
 
-#### Unzip
-```bash
-yum install -y unzip
-```
-
 #### Certbot
 ```bash
 yum install -y certbot
@@ -80,6 +75,7 @@ yum install -y certbot
 
 #### Composer
 ```bash
+yum install -y unzip # Required for Composer
 curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ```
 

--- a/community/installation-guides/panel/centos7.md
+++ b/community/installation-guides/panel/centos7.md
@@ -68,6 +68,11 @@ systemctl enable redis
 
 ### Additional Utilities
 
+#### Unzip
+```bash
+yum install -y unzip
+```
+
 #### Certbot
 ```bash
 yum install -y certbot


### PR DESCRIPTION
Unzip is required later on when using composer. Otherwise composer will issue a warning that unzip should be installed.