### PR TITLE
Remove redundant instructions to install certbot

### DIFF
--- a/community/installation-guides/panel/centos7.md
+++ b/community/installation-guides/panel/centos7.md
@@ -68,11 +68,6 @@ systemctl enable redis
 
 ### Additional Utilities
 
-#### Certbot
-```bash
-yum install -y certbot
-```
-
 #### Composer
 ```bash
 curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer


### PR DESCRIPTION
Installing certbot at this point is redundant, because it is referred to later on anyways by linking to /tutorials/creating_ssl_certificates.html where the user can choose whether to use cerbot or a different tool