### PR TITLE
Add Ubuntu 18.04 back

### DIFF
--- a/daemon/installing.md
+++ b/daemon/installing.md
@@ -7,6 +7,7 @@
 | ---------------- | ------- | :-------: | ----- |
 | **Ubuntu** | 14.04 | :warning: | Approaching EOL, not recommended for new installations. |
 | | 16.04 | :white_check_mark: | |
+| | 18.04 | :white_check_mark: | |
 | **CentOS** | 6 | :no_entry_sign: | Does not support all of the required packages. |
 | | 7 | :white_check_mark: | |
 | **Debian** | 8 | :warning: | Requires [kernel modifications](debian_8_docker.md) to run Docker. |


### PR DESCRIPTION
Title says it all. I noticed it got removed in https://github.com/pterodactyl/documentation/commit/97e2264715a80f19ccb150d9df20104813361009