### PR TITLE
force-enable redis on start

### DIFF
--- a/panel/getting_started.md
+++ b/panel/getting_started.md
@@ -50,6 +50,7 @@ apt -y install software-properties-common curl
 # Add additional repositories for PHP, Redis, and MariaDB
 LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php
 add-apt-repository -y ppa:chris-lea/redis-server
+systemctl enable --now redis-server
 curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash
 
 # Update repositories list


### PR DESCRIPTION
Redis doesn't auto start on some ubuntu versions to allow for configuration before redis is started. I've had multiple questions about this in the pterodactyl discord and believe it should be on by default do save people from issues where redis isnt online > their panel isnt working.