### PR TITLE
now start redis correctly

### DIFF
--- a/panel/getting_started.md
+++ b/panel/getting_started.md
@@ -214,7 +214,7 @@ when the service starts.
 
 If you are are using redis for your system, you will want to make sure to enable that it will start on boot. You can do that by running the following command: 
 ```bash
-sudo systemctl enable redis-server
+sudo systemctl enable --now redis-server
 ```
 
 Finally, enable the service and set it to boot on machine start.


### PR DESCRIPTION
new PR as i dont want to mess up the history, this does the same as https://github.com/pterodactyl/documentation/pull/100
Basically making sure that redis is started before we get all sorts of errors from people where redis wasnt on (offline is the default)