### PR TITLE
Link user to download files first [Master]

### DIFF
--- a/community/installation-guides/panel/debian9.md
+++ b/community/installation-guides/panel/debian9.md
@@ -124,4 +124,4 @@ The default Redis install is perfectly fine for the panel. If you have Redis alr
 [running another Redis instance](https://community.pivotal.io/s/article/How-to-setup-and-run-multiple-Redis-server-instances-on-a-Linux-host).
 
 ## Installing the Panel
-Excellent, we now have all of the required dependencies installed and configured. From here, follow the [official Panel installation documentation](/panel/getting_started.md#installation).
+Excellent, we now have all of the required dependencies installed and configured. From here, follow the [official Panel installation documentation](/panel/getting_started.md#download-files).

--- a/community/installation-guides/panel/ubuntu1804.md
+++ b/community/installation-guides/panel/ubuntu1804.md
@@ -113,4 +113,4 @@ The default Redis install is perfectly fine for the panel. If you have Redis alr
 [running another Redis instance](https://community.pivotal.io/s/article/How-to-setup-and-run-multiple-Redis-server-instances-on-a-Linux-host).
 
 ## Installing the Panel
-Excellent, we now have all of the required dependencies installed and configured. From here, follow the [official Panel installation documentation](/panel/getting_started.md#installation).
+Excellent, we now have all of the required dependencies installed and configured. From here, follow the [official Panel installation documentation](/panel/getting_started.md#download-files).


### PR DESCRIPTION
At the end of this community guide, it normally redirects the user to install the panel first, before downloading the files for it.

Changed from #installation to #download-files
