### PR TITLE
Rename 'Get Started' to 'Documentation' in menu

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -29,7 +29,7 @@ module.exports = {
         logo: '/pterodactyl-flat.png',
         nav: [
             {
-                text: 'Get Started',
+                text: 'Documentation',
                 link: '/project/introduction.md',
             },
             {


### PR DESCRIPTION
This makes more sense in my opinion. The menu item contains all documentation, not only the getting started guide.
The "Get Started" Button on the landing page will remain. 