### PR TITLE
Add missing config to docker registry page.

### DIFF
--- a/daemon/configuration.md
+++ b/daemon/configuration.md
@@ -85,6 +85,7 @@ The following will stop the daemon, remove the network, and start the daemon aga
 | ------------ | ------------- | ----- |
 | `username` | _none_ | The username to use when connecting to the registry. |
 | `password` | _none_ | The password associated with the account. |
+| `images` | _none_ | An array of images that are associated with the private registry. |
 | `auth` | _none_ | |
 | `email` | _none_ | |
 | `serveraddress` | _none_ | The address to the server the registry is located on. |


### PR DESCRIPTION
There is a missing option when defing a private registry in the config

https://github.com/pterodactyl/daemon/blob/b902cde7157e7cdd6b7a0a652db6840c3e766bbf/src/helpers/image.js#L75