### PR TITLE
Use deploy key for github-pages workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -17,6 +17,6 @@ jobs:
       if: github.ref == 'refs/heads/master'
       uses: peaceiris/actions-gh-pages@v2.2.0
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         PUBLISH_BRANCH: gh-pages
         PUBLISH_DIR: ./.vuepress/dist


### PR DESCRIPTION
@DaneEveritt please create a ssh deploy key as explained [here](https://github.com/peaceiris/actions-gh-pages#1-add-ssh-deploy-key) before merging.

resolves #142 