### PR TITLE
add sql warning for node db

### DIFF
--- a/tutorials/mysql_setup.md
+++ b/tutorials/mysql_setup.md
@@ -56,7 +56,7 @@ This section covers creating a MySQL user that has permission to create and modi
 :::
 
 ::: danger
-This is not for you to configure your mysql connections for servers. They should use the External IP of the DB server (or 172.18.0.1 for a database on the same node).
+This is not how to configure game servers.
 :::
 
 ### Creating a user

--- a/tutorials/mysql_setup.md
+++ b/tutorials/mysql_setup.md
@@ -55,6 +55,10 @@ FLUSH PRIVILEGES;
 This section covers creating a MySQL user that has permission to create and modify users. This allows the Panel to create per-server databases on the given host.
 :::
 
+::: danger
+This is not for you to configure your mysql connections for servers. They should use the External IP of the DB server (or 172.18.0.1 for a database on the same node).
+:::
+
 ### Creating a user
 If your database is on a different host than the one where your Panel or Daemon is installed make sure to use the IP address of the machine the Panel is running on. If you use `127.0.0.1` and try to connect externally, you will receive a connection refused error.
 


### PR DESCRIPTION
This is to add a warning about this not being how to configure a server to connect to a DB.

People probably won't read this either way.