### PR TITLE
Update php repo

### DIFF
--- a/community/installation-guides/panel/debian10.md
+++ b/community/installation-guides/panel/debian10.md
@@ -37,7 +37,7 @@ systemctl enable mariadb
 ## Install the PHP 7.3 repo for debian
 apt install -y ca-certificates apt-transport-https
 wget -q https://packages.sury.org/php/apt.gpg -O- | apt-key add -
-echo "deb https://packages.sury.org/php/ stretch main" | tee /etc/apt/sources.list.d/php.list
+echo "deb https://packages.sury.org/php/ buster main" | tee /etc/apt/sources.list.d/php.list
 
 ## Get apt updates
 apt update


### PR DESCRIPTION
Changed php repo's distro from stretch to buster. Currently, php7.x-curl's installation breaks as it's trying to find a version of libcurl that was included in stretch (Debian 9).