### PR TITLE
Minor changes to Debian 10 community panel installation guide

### DIFF
--- a/community/installation-guides/panel/debian10.md
+++ b/community/installation-guides/panel/debian10.md
@@ -5,7 +5,7 @@ to serve it using SSL.
 [[toc]]
 
 ::: tip
-This guide is based off the [official installation documentation](/panel/getting_started.md) but is tailored specifically for Debian 9.
+This guide is based off the [official installation documentation](/panel/getting_started.md) but is tailored specifically for Debian 10.
 :::
 
 ## Install Requirements


### PR DESCRIPTION
Replaced "9" in the Debian 10 community installation guide with "10".

There are also other problems with this guide, but I believe there is another pull request that resolves this (https://github.com/pterodactyl/documentation/pull/151, https://github.com/pterodactyl/documentation/pull/154 also incorporates the same changes).

I'm also wondering why an unofficial repository is used when there is an official one available. This goes for both Debian 9 and Debian 10 community panel installation guides. See these comments. https://github.com/pterodactyl/documentation/commit/8db2fc12dcd19423cde07c5d323ebafef452e3b9#r35750914 
https://github.com/pterodactyl/documentation/commit/e7e008086391d4e63710d5a957e098aaacee7514#r35750965

Cheers