### PR TITLE
Kernel Modifications - Boot from hard disk

### DIFF
--- a/daemon/kernel_modifications.md
+++ b/daemon/kernel_modifications.md
@@ -74,3 +74,6 @@ update grub and reboot, and you should be set.
 sudo update-grub
 sudo reboot
 ```
+
+## Boot from hard disk
+It's possible that even after you modified the GRUB configuration the server's still booted into a OVH kernel. If this happens to you, go to the OVH control panel and check the server's booting settings and make sure it's booting from hard disk instead of network boot.


### PR DESCRIPTION
Sometimes, for whatever reason, OVH sets the server's booting option to network boot, which will force the server to boot into a OVH customised kernel. I added a section about this.

I have a question: *why* are we suggesting the users to switch from a OVH customised kernel? Is it because the virtualization purposes?