### PR TITLE
Change fastcgi_pass to PHP 7.3

### DIFF
--- a/.snippets/webservers/nginx.conf
+++ b/.snippets/webservers/nginx.conf
@@ -45,7 +45,7 @@ server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php/php7.2-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.3-fpm.sock;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param PHP_VALUE "upload_max_filesize = 100M \n post_max_size=100M";


### PR DESCRIPTION
Changed the value of fastcgi_pass to be compatible with PHP 7.3. In the [Debian 10 Community Guide](https://pterodactyl.io/community/installation-guides/panel/debian10.html), you install PHP 7.3 but the config file is for 7.2.