### PR TITLE
Resolve dependency errors

### DIFF
--- a/community/installation-guides/daemon/debian10.md
+++ b/community/installation-guides/daemon/debian10.md
@@ -43,7 +43,7 @@ systemctl start docker
 curl -sL https://deb.nodesource.com/setup_10.x | bash -
 
 ## Install nodejs
-apt install -y nodejs npm
+apt install -y nodejs
 ```
 
 ## Installing the Daemon


### PR DESCRIPTION
Installing both nodejs and npm causes dependency errors. Just installing nodejs pulls in the correct npm version automagically.

```The following packages have unmet dependencies:
 nodejs : Conflicts: npm
 npm : Depends: node-gyp (>= 3.6.2~) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.```