### PR TITLE
Update deaemon installing.md

### DIFF
--- a/daemon/installing.md
+++ b/daemon/installing.md
@@ -132,7 +132,7 @@ curl -L https://github.com/pterodactyl/daemon/releases/download/v0.6.12/daemon.t
 Finally, we need to install the dependencies that allow the Daemon to run properly. This command will most likely
 take a few minutes to run, please do not interrupt it.
 ``` bash
-npm install --only=production
+sudo npm install --only=production
 ```
 
 ## Configure Daemon


### PR DESCRIPTION
Change the line of npm install --only=production
To start with sudo, Some people seem to be getting this error

npm ERR! mmmagic@0.5.0 install: node-gyp rebuild
npm ERR! Exit status 1

It seems that using sudo often fixes the problem