### PR TITLE
add npm flags to keep it from erroring

### DIFF
--- a/daemon/installing.md
+++ b/daemon/installing.md
@@ -138,7 +138,7 @@ You can safely ignore this output. Do not run the audit fix command, you _will_ 
 :::
 
 ``` bash
-npm install --only=production
+npm install --only=production --no-audit --unsafe-perm
 ```
 
 ## Configure Daemon


### PR DESCRIPTION
This adds the `--no-audit` and  `--unsafe-perm` flags so it actually installs properly as root.