### PR TITLE
Remove Ubuntu 14 / Remove forever

### DIFF
--- a/daemon/0.6/installing.md
+++ b/daemon/0.6/installing.md
@@ -5,8 +5,7 @@
 ## Supported Systems
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
-| **Ubuntu** | 14.04 | :warning: | Approaching EOL, not recommended for new installations. |
-| | 16.04 | :white_check_mark: | |
+| **Ubuntu** | 16.04 | :white_check_mark: | |
 | | 18.04 | :white_check_mark: | |
 | **CentOS** | 6 | :no_entry_sign: | Does not support all of the required packages. |
 | | 7 | :white_check_mark: | |
@@ -191,19 +190,4 @@ Then, run the commands below to reload systemd and start the daemon.
 
 ``` bash
 systemctl enable --now wings
-```
-
-### Daemonizing (using Forever)
-Forever allows us to run the daemon as a pseudo-daemonized application. We can exit our terminal session without
-killing the process, and we don't have to run it in a screen. Inside the daemon directory, run the commands below which
-will install forever and then start the process in the background.
-
-You should use this only if your system does not support systemd.
-
-``` bash
-npm install -g forever
-forever start src/index.js
-
-# To stop the daemon use:
-forever stop src/index.js
 ```

--- a/daemon/0.6/installing.md
+++ b/daemon/0.6/installing.md
@@ -7,7 +7,7 @@
 | ---------------- | ------- | :-------: | ----- |
 | **Ubuntu** | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
 | | 20.04 | :white_check_mark: |
-| **CentOS** | 7 | :warning: | Extra repos are required. |
+| **CentOS** | 7 | :warning: | Extra repos are required |
 | | 8 | :white_check_mark: | |
 | **Debian** | 9 | :white_check_mark: | |
 | | 10 | :white_check_mark: | |

--- a/daemon/0.6/installing.md
+++ b/daemon/0.6/installing.md
@@ -5,12 +5,14 @@
 ## Supported Systems
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
-| **Ubuntu** | 16.04 | :white_check_mark: | |
-| | 18.04 | :white_check_mark: | |
+| **Ubuntu** | 16.04 | :warning: | Ubuntu 16.04 is nearing end of life. |
+| | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
 | **CentOS** | 6 | :no_entry_sign: | Does not support all of the required packages. |
-| | 7 | :white_check_mark: | |
+| | 7 | :warning: | Extra repos are required. |
+| | 8 | :white_check_mark: | |
 | **Debian** | 8 | :warning: | Requires [kernel modifications](debian_8_docker.md) to run Docker. |
 | | 9 | :white_check_mark: | |
+| | 10 | :white_check_mark: | |
 | **Alpine Linux** | 3.4+ | :warning: | Not officially supported, but reportedly works. |
 | **RHEL** | 7 | :warning: | Not officially supported, should work. |
 | **Fedora** | 28 | :warning: | Not officially supported, should work. |

--- a/daemon/0.6/installing.md
+++ b/daemon/0.6/installing.md
@@ -7,16 +7,10 @@
 | ---------------- | ------- | :-------: | ----- |
 | **Ubuntu** | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
 | | 20.04 | :white_check_mark: |
-| **CentOS** | 6 | :no_entry_sign: | Does not support all of the required packages. |
-| | 7 | :warning: | Extra repos are required. |
+| **CentOS** | 7 | :warning: | Extra repos are required. |
 | | 8 | :white_check_mark: | |
-| **Debian** | 8 | :warning: | Requires [kernel modifications](debian_8_docker.md) to run Docker. |
-| | 9 | :white_check_mark: | |
+| **Debian** | 9 | :white_check_mark: | |
 | | 10 | :white_check_mark: | |
-| **Alpine Linux** | 3.4+ | :warning: | Not officially supported, but reportedly works. |
-| **RHEL** | 7 | :warning: | Not officially supported, should work. |
-| **Fedora** | 28 | :warning: | Not officially supported, should work. |
-| | 29 | :warning: | Not officially supported, should work. |
 
 ## System Requirements
 In order to run the Daemon you will need a system capable of running Docker containers. Most VPS and almost all

--- a/daemon/0.6/installing.md
+++ b/daemon/0.6/installing.md
@@ -5,8 +5,8 @@
 ## Supported Systems
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
-| **Ubuntu** | 16.04 | :warning: | Ubuntu 16.04 is nearing end of life. |
-| | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
+| **Ubuntu** | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
+| | 20.04 | :white_check_mark: |
 | **CentOS** | 6 | :no_entry_sign: | Does not support all of the required packages. |
 | | 7 | :warning: | Extra repos are required. |
 | | 8 | :white_check_mark: | |

--- a/panel/0.7/getting_started.md
+++ b/panel/0.7/getting_started.md
@@ -20,14 +20,11 @@ this software on an OpenVZ based system you will &mdash; most likely &mdash; not
 
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
-| **Ubuntu** | 14.04 | :warning: | Documentation assumes changes to `systemd` introduced in `16.04` |
-| | 16.04 | :warning: | Ubuntu 16.04 is nearing end of life. |
-| | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
-| **CentOS** | 6 | :no_entry_sign: | Does not support all of the required packages. |
-| | 7 | :white_check_mark: | Extra repos are required. |
+| **Ubuntu** | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
+| | 20.04 | :white_check_mark: | |
+| **CentOS** | 7 | :white_check_mark: | Extra repos are required. |
 | | 8 | :white_check_mark: | All required packages are part of the base repos. |
-| **Debian** | 8 | :warning: | Debian 8 may need modifications to work with the latest docker and other requirements for the panel/daemon |
-| | 9 | :white_check_mark: | Extra repos are required. |
+| **Debian** | 9 | :white_check_mark: | Extra repos are required. |
 | | 10 | :white_check_mark: | All required packages are part of the base repos. |
 
 ## Dependencies

--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -27,11 +27,9 @@ this software on an OpenVZ based system you will &mdash; most likely &mdash; not
 | ---------------- | ------- | :-------: | ----- |
 | **Ubuntu** | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
 | | 20.04 | :white_check_mark: | |
-| **CentOS** | 6 | :no_entry_sign: | Does not support all of the required packages. |
-| | 7 | :white_check_mark: | Extra repos are required. |
+| **CentOS** | 7 | :white_check_mark: | Extra repos are required. |
 | | 8 | :white_check_mark: | All required packages are part of the base repos. |
-| **Debian** | 8 | :warning: | Debian 8 may need modifications to work with the latest docker and other requirements for the panel/daemon |
-| | 9 | :white_check_mark: | Extra repos are required. |
+| **Debian** | 9 | :white_check_mark: | Extra repos are required. |
 | | 10 | :white_check_mark: | All required packages are part of the base repos. |
 
 ## Dependencies

--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -25,8 +25,8 @@ this software on an OpenVZ based system you will &mdash; most likely &mdash; not
 
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
-| **Ubuntu** | 16.04 | :warning: | Ubuntu 16.04 is nearing end of life. |
-| | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
+| **Ubuntu** | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
+| | 20.04 | :white_check_mark: | |
 | **CentOS** | 6 | :no_entry_sign: | Does not support all of the required packages. |
 | | 7 | :white_check_mark: | Extra repos are required. |
 | | 8 | :white_check_mark: | All required packages are part of the base repos. |

--- a/wings/1.0/installing.md
+++ b/wings/1.0/installing.md
@@ -14,7 +14,7 @@ This software _requires Pterodactyl 1.0_ in order to run.
 ## Supported Systems
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
-| **Ubuntu** | 18.04 | :white_check_mark: | |
+| **Ubuntu** | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
 | | 20.04 | :white_check_mark: | |
 | **CentOS** | 7 | :white_check_mark: | |
 | | 8 | :white_check_mark: | |

--- a/wings/1.0/installing.md
+++ b/wings/1.0/installing.md
@@ -14,17 +14,12 @@ This software _requires Pterodactyl 1.0_ in order to run.
 ## Supported Systems
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
-| **Ubuntu** | 16.04 | :warning: | Not Recommended, End of Life(April 2019) |
-| | 18.04 | :white_check_mark: | Recommended  |
-| | 20.04 | :warning: | Not offically supported, should work. |
+| **Ubuntu** | 18.04 | :white_check_mark: | |
+| | 20.04 | :white_check_mark: | |
 | **CentOS** | 7 | :white_check_mark: | |
 | | 8 | :white_check_mark: | |
-| **Debian** | 8 | :warning: | Requires [kernel modifications](/daemon/debian_8_docker.md) to run Docker. |
-| | 9 | :white_check_mark: | |
+| **Debian** | 9 | :white_check_mark: | |
 | | 10 | :white_check_mark: | |
-| **Alpine Linux** | 3.4+ | :warning: | Not officially supported, but reportedly works. |
-| **RHEL** | 7+ | :warning: | Not officially supported, should work. |
-| **Fedora** | 28+ | :warning: | Not officially supported, should work. |
 
 ## System Requirements
 In order to run the Daemon you will need a system capable of running Docker containers. Most VPS and almost all

--- a/wings/1.0/installing.md
+++ b/wings/1.0/installing.md
@@ -14,18 +14,17 @@ This software _requires Pterodactyl 1.0_ in order to run.
 ## Supported Systems
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
-| **Ubuntu** | 14.04 | :no_entry_sign: | Does not support `systemd`. |
-| | 16.04 | :white_check_mark: | |
-| | 18.04 | :white_check_mark: | |
-| **CentOS** | 6 | :no_entry_sign: | Does not support all of the required packages. |
-| | 7 | :white_check_mark: | |
+| **Ubuntu** | 16.04 | :warning: | Not Recommended, End of Life(April 2019) |
+| | 18.04 | :white_check_mark: | Recommended  |
+| | 20.04 | :warning: | Not offically supported, should work. |
+| **CentOS** | 7 | :white_check_mark: | |
+| | 8 | :white_check_mark: | |
 | **Debian** | 8 | :warning: | Requires [kernel modifications](/daemon/debian_8_docker.md) to run Docker. |
 | | 9 | :white_check_mark: | |
 | | 10 | :white_check_mark: | |
 | **Alpine Linux** | 3.4+ | :warning: | Not officially supported, but reportedly works. |
-| **RHEL** | 7 | :warning: | Not officially supported, should work. |
-| **Fedora** | 28 | :warning: | Not officially supported, should work. |
-| | 29 | :warning: | Not officially supported, should work. |
+| **RHEL** | 7+ | :warning: | Not officially supported, should work. |
+| **Fedora** | 28+ | :warning: | Not officially supported, should work. |
 
 ## System Requirements
 In order to run the Daemon you will need a system capable of running Docker containers. Most VPS and almost all


### PR DESCRIPTION
Removed forever, 99% of users are using a distro with systemd. If they're not..... Then.... Yeh they should update their distro unless there's one out there that people use and require it. 

Removed ubuntu 14.04 as nobody in their right mind should be using it.