### PR TITLE
Updated supproted systems

### DIFF
--- a/daemon/0.6/installing.md
+++ b/daemon/0.6/installing.md
@@ -5,17 +5,12 @@
 ## Supported Systems
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
-| **Ubuntu** | 14.04 | :warning: | Approaching EOL, not recommended for new installations. |
-| | 16.04 | :white_check_mark: | |
-| | 18.04 | :white_check_mark: | |
-| **CentOS** | 6 | :no_entry_sign: | Does not support all of the required packages. |
-| | 7 | :white_check_mark: | |
-| **Debian** | 8 | :warning: | Requires [kernel modifications](debian_8_docker.md) to run Docker. |
-| | 9 | :white_check_mark: | |
-| **Alpine Linux** | 3.4+ | :warning: | Not officially supported, but reportedly works. |
-| **RHEL** | 7 | :warning: | Not officially supported, should work. |
-| **Fedora** | 28 | :warning: | Not officially supported, should work. |
-| | 29 | :warning: | Not officially supported, should work. |
+| **Ubuntu** | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
+| | 20.04 | :white_check_mark: |
+| **CentOS** | 7 | :warning: | Extra repos are required |
+| | 8 | :white_check_mark: | |
+| **Debian** | 9 | :white_check_mark: | |
+| | 10 | :white_check_mark: | |
 
 ## System Requirements
 In order to run the Daemon you will need a system capable of running Docker containers. Most VPS and almost all
@@ -191,19 +186,4 @@ Then, run the commands below to reload systemd and start the daemon.
 
 ``` bash
 systemctl enable --now wings
-```
-
-### Daemonizing (using Forever)
-Forever allows us to run the daemon as a pseudo-daemonized application. We can exit our terminal session without
-killing the process, and we don't have to run it in a screen. Inside the daemon directory, run the commands below which
-will install forever and then start the process in the background.
-
-You should use this only if your system does not support systemd.
-
-``` bash
-npm install -g forever
-forever start src/index.js
-
-# To stop the daemon use:
-forever stop src/index.js
 ```

--- a/panel/0.7/getting_started.md
+++ b/panel/0.7/getting_started.md
@@ -20,14 +20,11 @@ this software on an OpenVZ based system you will &mdash; most likely &mdash; not
 
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
-| **Ubuntu** | 14.04 | :warning: | Documentation assumes changes to `systemd` introduced in `16.04` |
-| | 16.04 | :warning: | Ubuntu 16.04 is nearing end of life. |
-| | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
-| **CentOS** | 6 | :no_entry_sign: | Does not support all of the required packages. |
-| | 7 | :white_check_mark: | Extra repos are required. |
+| **Ubuntu** | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
+| | 20.04 | :white_check_mark: | |
+| **CentOS** | 7 | :white_check_mark: | Extra repos are required. |
 | | 8 | :white_check_mark: | All required packages are part of the base repos. |
-| **Debian** | 8 | :warning: | Debian 8 may need modifications to work with the latest docker and other requirements for the panel/daemon |
-| | 9 | :white_check_mark: | Extra repos are required. |
+| **Debian** | 9 | :white_check_mark: | Extra repos are required. |
 | | 10 | :white_check_mark: | All required packages are part of the base repos. |
 
 ## Dependencies

--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -25,13 +25,11 @@ this software on an OpenVZ based system you will &mdash; most likely &mdash; not
 
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
-| **Ubuntu** | 16.04 | :warning: | Ubuntu 16.04 is nearing end of life. |
-| | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
-| **CentOS** | 6 | :no_entry_sign: | Does not support all of the required packages. |
-| | 7 | :white_check_mark: | Extra repos are required. |
+| **Ubuntu** | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
+| | 20.04 | :white_check_mark: | |
+| **CentOS** | 7 | :white_check_mark: | Extra repos are required. |
 | | 8 | :white_check_mark: | All required packages are part of the base repos. |
-| **Debian** | 8 | :warning: | Debian 8 may need modifications to work with the latest docker and other requirements for the panel/daemon |
-| | 9 | :white_check_mark: | Extra repos are required. |
+| **Debian** | 9 | :white_check_mark: | Extra repos are required. |
 | | 10 | :white_check_mark: | All required packages are part of the base repos. |
 
 ## Dependencies

--- a/project/introduction.md
+++ b/project/introduction.md
@@ -24,7 +24,6 @@ In addition to our standard nest of supported games, our community is constantly
 and there are plenty more games available provided by the community. Some of these games include:
 
 * Factorio
-* Terraria
 * San Andreas: MP
 * Pocketmine MP
 * Squad

--- a/wings/1.0/installing.md
+++ b/wings/1.0/installing.md
@@ -14,18 +14,12 @@ This software _requires Pterodactyl 1.0_ in order to run.
 ## Supported Systems
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
-| **Ubuntu** | 14.04 | :no_entry_sign: | Does not support `systemd`. |
-| | 16.04 | :white_check_mark: | |
-| | 18.04 | :white_check_mark: | |
-| **CentOS** | 6 | :no_entry_sign: | Does not support all of the required packages. |
-| | 7 | :white_check_mark: | |
-| **Debian** | 8 | :warning: | Requires [kernel modifications](/daemon/debian_8_docker.md) to run Docker. |
-| | 9 | :white_check_mark: | |
+| **Ubuntu** | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
+| | 20.04 | :white_check_mark: | |
+| **CentOS** | 7 | :white_check_mark: | |
+| | 8 | :white_check_mark: | |
+| **Debian** | 9 | :white_check_mark: | |
 | | 10 | :white_check_mark: | |
-| **Alpine Linux** | 3.4+ | :warning: | Not officially supported, but reportedly works. |
-| **RHEL** | 7 | :warning: | Not officially supported, should work. |
-| **Fedora** | 28 | :warning: | Not officially supported, should work. |
-| | 29 | :warning: | Not officially supported, should work. |
 
 ## System Requirements
 In order to run the Daemon you will need a system capable of running Docker containers. Most VPS and almost all


### PR DESCRIPTION
Updated Supported Systems table for all the installs so they all match.
Removed 14.04/16.06
Removed REHL/Alpine/Fedora
Removed old versions of Debian/CentOS
Added newer versions of Debian/CentOS
Added Ubuntu 20.04
Removed the duplicate supported game, Terraria

Remade PR of #199.... The proper way...