### PR TITLE
Fix suggested assets path in theme setup docs

### DIFF
--- a/community/tutorials/custom_theme_setup.md
+++ b/community/tutorials/custom_theme_setup.md
@@ -18,7 +18,7 @@ Give theme name:
  > (Press Enter)
 
  Where will assets be located? []:
- > /themes/(MyThemeNameHere) (Example: /themes/MyThemeNameHere)
+ > themes/(MyThemeNameHere) (Example: themes/MyThemeNameHere)
 
  Extends an other theme? (yes/no) [no]:
  > (Press Enter)


### PR DESCRIPTION
With the leading /, the path is interpreted as absolute so will attempt to load theme resources from `http://themes/<themename>/resource`. After removing this leading / themes can be created successfully.