### PR TITLE
Added a note to help users with permissions for entrypoint.sh

### DIFF
--- a/community/config/eggs/creating_a_custom_image.md
+++ b/community/config/eggs/creating_a_custom_image.md
@@ -145,3 +145,6 @@ java -Xms128M -Xmx1024M -jar server.jar
 
 ## Run the Command
 The last step is to run this modified startup command, which is done with the line `${MODIFIED_STARTUP}`.
+
+### Note
+Sometimes you may need to change the permissions of the `entrypoint.sh` file, on linux you can do this by executing `chmod +x entrypoint.sh` in the directory where the file is.


### PR DESCRIPTION
I have added this note to the bottom of page to help user set the right permissions for their entrypoint.sh I had this problem, so I would just like to let other user know before they have to take to the Pterodactyl Discord Server. I just thought it would be a nice note. I don't mind if you change the way it is said or formatted, as long as it has the same meaning as what I wrote.