### PR TITLE
Add links to community guides for supported os table, uniformity changes within community guides.

### DIFF
--- a/community/installation-guides/daemon/centos7.md
+++ b/community/installation-guides/daemon/centos7.md
@@ -1,6 +1,5 @@
 # CentOS 7
-In this guide we will install Pterodactyl's Daemon 0.6.X — including all of it's dependencies — and configure it
-to use a SSL connection.
+In this guide we will install Pterodactyl's Daemon v0.6.X — including all of it's dependencies — and configure it to use a SSL connection.
 
 [[toc]]
 

--- a/community/installation-guides/daemon/centos8.md
+++ b/community/installation-guides/daemon/centos8.md
@@ -1,5 +1,5 @@
 # CentOS 8
-In this guide we will install Pterodactyl's Daemon 0.6.X — including all of it's dependencies — and configure it to use a SSL connection.
+In this guide we will install Pterodactyl's Daemon v0.6.X — including all of it's dependencies — and configure it to use a SSL connection.
 
 [[toc]]
 
@@ -8,7 +8,7 @@ This guide is based off the [official installation documentation](/daemon/instal
 :::
 
 ## Install Requirements
-We will first begin by installing all of the Daemon's [required dependencies](/daemon/installing.md#dependencies).
+We will first begin by installing all of the Daemon's [required](/daemon/installing.md#dependencies) dependencies.
 
 ### General Requirements
 ```bash

--- a/community/installation-guides/daemon/debian10.md
+++ b/community/installation-guides/daemon/debian10.md
@@ -1,6 +1,5 @@
 # Debian 10
-In this guide we will install Pterodactyl's Daemon 0.6.X — including all of it's dependencies — and configure it
-to use a SSL connection.
+In this guide we will install Pterodactyl's Daemon v0.6.X — including all of it's dependencies — and configure it to use a SSL connection.
 
 [[toc]]
 

--- a/community/installation-guides/daemon/debian9.md
+++ b/community/installation-guides/daemon/debian9.md
@@ -1,6 +1,5 @@
 # Debian 9
-In this guide we will install Pterodactyl's Daemon 0.6.X — including all of it's dependencies — and configure it
-to use a SSL connection.
+In this guide we will install Pterodactyl's Daemon v0.6.X — including all of it's dependencies — and configure it to use a SSL connection.
 
 [[toc]]
 

--- a/community/installation-guides/daemon/ubuntu1804.md
+++ b/community/installation-guides/daemon/ubuntu1804.md
@@ -1,6 +1,5 @@
 # Ubuntu 18.04
-In this guide we will install Pterodactyl's Daemon 0.6.X - including all of it's dependencies — and configure it
-to use a SSL connection.
+In this guide we will install Pterodactyl's Daemon v0.6.X — including all of it's dependencies — and configure it to use a SSL connection.
 
 [[toc]]
 

--- a/community/installation-guides/daemon/ubuntu2004.md
+++ b/community/installation-guides/daemon/ubuntu2004.md
@@ -1,6 +1,5 @@
 # Ubuntu 20.04
-In this guide we will install Pterodactyl's Daemon 0.6.X — including all of it's dependencies — and configure it
-to use a SSL connection.
+In this guide we will install Pterodactyl's Daemon v0.6.X — including all of it's dependencies — and configure it to use a SSL connection.
 
 [[toc]]
 

--- a/community/installation-guides/panel/centos7.md
+++ b/community/installation-guides/panel/centos7.md
@@ -1,5 +1,5 @@
 # CentOS 7
-In this guide we will install Pterodactyl — including all of it's dependencies — and configure our webserver
+In this guide we will install Pterodactyl v0.7.X — including all of it's dependencies — and configure our webserver
 to serve it using SSL.
 
 [[toc]]

--- a/community/installation-guides/panel/centos8.md
+++ b/community/installation-guides/panel/centos8.md
@@ -1,5 +1,5 @@
 # CentOS 8
-In this guide we will install Pterodactyl — including all of it's dependencies — and configure our webserver to serve it using SSL.
+In this guide we will install Pterodactyl v0.7.X — including all of it's dependencies — and configure our webserver to serve it using SSL.
 
 [[toc]]
 

--- a/community/installation-guides/panel/debian10.md
+++ b/community/installation-guides/panel/debian10.md
@@ -1,6 +1,5 @@
 # Debian 10
-In this guide we will install Pterodactyl — including all of it's dependencies — and configure our webserver
-to serve it using SSL.
+In this guide we will install Pterodactyl v0.7.X — including all of it's dependencies — and configure our webserver to serve it using SSL.
 
 [[toc]]
 
@@ -16,7 +15,7 @@ We will first begin by installing all of Pterodactyl's [required](/panel/getting
 ## Get apt updates
 apt update
 
-## Install MariaDB 10.3
+## Install MariaDB
 apt install -y mariadb-common mariadb-server mariadb-client
 
 ## Start maraidb

--- a/community/installation-guides/panel/debian9.md
+++ b/community/installation-guides/panel/debian9.md
@@ -1,6 +1,5 @@
 # Debian 9
-In this guide we will install Pterodactyl — including all of it's dependencies — and configure our webserver
-to serve it using SSL.
+In this guide we will install Pterodactyl v0.7.X — including all of it's dependencies — and configure our webserver to serve it using SSL.
 
 [[toc]]
 
@@ -18,7 +17,7 @@ apt install -y software-properties-common dirmngr
 ## Get apt updates
 apt update
 
-## Install MariaDB 10.1
+## Install MariaDB
 apt install -y mariadb-common mariadb-server mariadb-client
 
 ## Start maraidb

--- a/community/installation-guides/panel/ubuntu1804.md
+++ b/community/installation-guides/panel/ubuntu1804.md
@@ -1,6 +1,5 @@
 # Ubuntu 18.04
-In this guide we will install Pterodactyl — including all of it's dependencies — and configure our webserver
-to serve it using SSL.
+In this guide we will install Pterodactyl v0.7.X — including all of it's dependencies — and configure our webserver to serve it using SSL.
 
 [[toc]]
 
@@ -16,7 +15,7 @@ We will first begin by installing all of Pterodactyl's [required](/panel/getting
 ## Get apt updates
 apt update -y
 
-## Install MariaDB 10.1
+## Install MariaDB
 apt install -y mariadb-common mariadb-server mariadb-client
 
 ## Start MariaDB
@@ -25,7 +24,6 @@ systemctl enable mariadb
 ```
 
 ### PHP 7.2
-
 ```bash
 ## Get apt updates
 apt update -y
@@ -35,13 +33,11 @@ apt install -y php7.2 php7.2-cli php7.2-gd php7.2-mysql php7.2-pdo php7.2-mbstri
 ```
 
 ### Nginx
-
 ```bash
 apt install -y nginx
 ```
 
 ### Redis
-
 ```bash
 apt install -y redis-server
 

--- a/community/installation-guides/panel/ubuntu2004.md
+++ b/community/installation-guides/panel/ubuntu2004.md
@@ -1,5 +1,5 @@
 # Ubuntu 20.04
-In this guide we will install Pterodactyl 0.7.X — including all of it's dependencies — and configure our webserver to serve it using SSL.
+In this guide we will install Pterodactyl v0.7.X — including all of it's dependencies — and configure our webserver to serve it using SSL.
 
 [[toc]]
 
@@ -23,8 +23,7 @@ systemctl start mariadb
 systemctl enable mariadb
 ```
 
-### PHP
-
+### PHP 7.4
 ```bash
 ## Get apt updates
 apt update -y

--- a/daemon/0.6/installing.md
+++ b/daemon/0.6/installing.md
@@ -6,11 +6,11 @@
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
 | **Ubuntu** | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
-| | 20.04 | :white_check_mark: |
-| **CentOS** | 7 | :warning: | Extra repos are required |
-| | 8 | :white_check_mark: | |
-| **Debian** | 9 | :white_check_mark: | |
-| | 10 | :white_check_mark: | |
+| | [20.04](/community/installation-guides/daemon/ubuntu2004.html) | :white_check_mark: |
+| **CentOS** | [7](/community/installation-guides/daemon/centos7.html) | :warning: | Extra repos are required |
+| | [8](/community/installation-guides/daemon/centos8.html) | :white_check_mark: | |
+| **Debian** | [9](/community/installation-guides/daemon/debian9.html) | :white_check_mark: | |
+| | [10](/community/installation-guides/daemon/debian10.html) | :white_check_mark: | |
 
 ## System Requirements
 In order to run the Daemon you will need a system capable of running Docker containers. Most VPS and almost all

--- a/panel/0.7/getting_started.md
+++ b/panel/0.7/getting_started.md
@@ -21,11 +21,11 @@ this software on an OpenVZ based system you will &mdash; most likely &mdash; not
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
 | **Ubuntu** | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
-| | 20.04 | :white_check_mark: | |
-| **CentOS** | 7 | :white_check_mark: | Extra repos are required. |
-| | 8 | :white_check_mark: | All required packages are part of the base repos. |
-| **Debian** | 9 | :white_check_mark: | Extra repos are required. |
-| | 10 | :white_check_mark: | All required packages are part of the base repos. |
+| | [20.04](/community/installation-guides/panel/ubuntu2004.html) | :white_check_mark: | |
+| **CentOS** | [7](/community/installation-guides/panel/centos7.html) | :white_check_mark: | Extra repos are required. |
+| | [8](/community/installation-guides/panel/centos8.html) | :white_check_mark: | All required packages are part of the base repos. |
+| **Debian** | [9](/community/installation-guides/panel/debian9.html) | :white_check_mark: | Extra repos are required. |
+| | [10](/community/installation-guides/panel/debian10.html) | :white_check_mark: | All required packages are part of the base repos. |
 
 ## Dependencies
 * PHP `7.2` with the following extensions: `cli`, `openssl`, `gd`, `mysql`, `PDO`, `mbstring`, `tokenizer`, `bcmath`, `xml` or `dom`, `curl`, `zip`, and `fpm` if you are planning to use nginx


### PR DESCRIPTION
Added links to OS versions to show the community guide that's specific to that OS and version.
Community guides now state they're for v0.7, I'm sure they would work for v1.0 but they should be tested to make sure.
