### PR TITLE
Variable <phpversion> for 'fastcgi_pass' in webserver config

### DIFF
--- a/.snippets/webservers/nginx-nossl.conf
+++ b/.snippets/webservers/nginx-nossl.conf
@@ -24,7 +24,7 @@ server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php/php7.2-fpm.sock;
+        fastcgi_pass unix:/run/php/<phpversion>-fpm.sock;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param PHP_VALUE "upload_max_filesize = 100M \n post_max_size=100M";

--- a/.snippets/webservers/nginx.conf
+++ b/.snippets/webservers/nginx.conf
@@ -45,7 +45,7 @@ server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php/php7.2-fpm.sock;
+        fastcgi_pass unix:/run/php/<phpversion>-fpm.sock;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param PHP_VALUE "upload_max_filesize = 100M \n post_max_size=100M";

--- a/panel/0.7/webserver_configuration.md
+++ b/panel/0.7/webserver_configuration.md
@@ -8,8 +8,8 @@ users by default.
 :::
 
 ## NGINX
-You should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
-`pterodactyl.conf` and place it in `/etc/nginx/sites-available/`, or &mdash; if on CentOS, `/etc/nginx/conf.d/`.
+You should paste the contents of the file below, replacing `<domain>` with your domain name being used and `<phpversion>` with the php version 
+being used in a file called `pterodactyl.conf` and place it in `/etc/nginx/sites-available/`, or &mdash; if on CentOS, `/etc/nginx/conf.d/`.
 
 ### NGINX With SSL
 This configuration assumes that you will be using SSL on both the Panel and Daemons for significantly improved communication
@@ -20,13 +20,13 @@ Let's Encrypt.
 When using the SSL configuration you MUST create SSL certificates, otherwise your NGINX will fail to start.  See [Creating SSL Certificates](/tutorials/creating_ssl_certificates.html) documentation page for how to create these certificates before continuing.
 :::
 
-<<< @/.snippets/webservers/nginx.conf{5,11,26-27}
+<<< @/.snippets/webservers/nginx.conf{5,11,26-27,48}
 
 Continue reading to the bottom of this section for the final steps with NGINX!
 
 ### NGINX Without SSL
 
-<<< @/.snippets/webservers/nginx-nossl.conf{3}
+<<< @/.snippets/webservers/nginx-nossl.conf{3,27}
 
 ### Enabling Configuration
 The final step is to enable your NGINX configuration and restart it.


### PR DESCRIPTION
I think this change will help people not running into problems when certain parts of the documentation are refering to php7.2 and others to php7.3 or php7.4.