### PR TITLE
Remove Ubuntu 14 warning about forever

### DIFF
--- a/daemon/0.6/installing.md
+++ b/daemon/0.6/installing.md
@@ -155,10 +155,6 @@ sudo npm start
 ```
 
 ### Daemonizing (using systemd)
-::: warning
-If you are using Ubuntu 14 you cannot use `systemd` to manage your Daemon. Please see the instructions below on using
-"forever" to run the daemon.
-:::
 
 Running Pterodactyl Daemon in the background is a simple task, just make sure that it runs without errors before doing
 this. Place the contents below in a file called `wings.service` in the `/etc/systemd/system` directory.


### PR DESCRIPTION
Removes the warning that should've been removed when forever was removed. Nobody should be using Ubuntu 14....