### PR TITLE
Remove strip-componets from tar

### DIFF
--- a/panel/1.0/upgrade/1.0.md
+++ b/panel/1.0/upgrade/1.0.md
@@ -14,7 +14,7 @@ to ensure that you're in the `/var/www/pterodactyl` directory as the command bel
 into your current folder.
 
 ``` bash
-curl -L https://github.com/pterodactyl/panel/releases/download/v1.0.0-beta.6/panel.tar.gz | tar --strip-components=1 -xzv
+curl -L https://github.com/pterodactyl/panel/releases/download/v1.0.0-beta.6/panel.tar.gz | tar -xzv
 ```
 
 Once all of the files are downloaded we need to set the correct permissions on the cache and storage directories to avoid


### PR DESCRIPTION
structure of the .tar.gz changed to stripping the first folder results in it getting puked everywhere...
Updates were previously in a folder of `panel-1.0.0-beta.#` now they're not, so stripping the first dir is no longer required