### PR TITLE
Update Documentation

### DIFF
--- a/panel/1.0/upgrade/0.7_to_1.0.md
+++ b/panel/1.0/upgrade/0.7_to_1.0.md
@@ -30,10 +30,10 @@ are not always detected properly, so simply uppacking over this location will re
 # Delete the app directory to ensure we start with a clean slate here. This will not affect any
 # of your settings or servers.
 curl -L -o panel.tar.gz https://github.com/pterodactyl/panel/releases/download/v1.0.0-rc.2/panel.tar.gz
-rm -rf $(find app public resources -d | head -n -1 | grep -Fv "$(tar -tf panel.tar.gz)")
+rm -rf $(find app public resources -depth | head -n -1 | grep -Fv "$(tar -tf panel.tar.gz)")
 
 # Download the updated files and delete the archive file.
-tar --strip-components=1 -xzv panel.tar.gz && rm -rf panel.tar.gz
+tar --strip-components=1 -xzvf panel.tar.gz && rm -rf panel.tar.gz
 ```
 
 Once all of the files are downloaded we need to set the correct permissions on the cache and storage directories to avoid


### PR DESCRIPTION
Make usage of `find` command POSIX compliant, and fixed an error in this `tar` command.

These commands barely work for me in the first place, but no one could even run them with a malformed tar command.

Logs that guided this issue
```
$ rm -rf $(find app public resources -d | head -n -1 | grep -Fv "$(tar -tf panel.tar.gz)")
find: warning: the -d option is deprecated; please use -depth instead, because the latter is a POSIX-compliant feature.
find: ‘app’: No such file or directory
find: ‘public’: No such file or directory
find: ‘resources’: No such file or directory

$ tar --strip-components=1 -xzv panel.tar.gz && rm -rf panel.tar.gz
tar: Refusing to read archive contents from terminal (missing -f option?)
tar: Error is not recoverable: exiting now
```