### PR TITLE
Update MySQL documentation

### DIFF
--- a/panel/0.7/getting_started.md
+++ b/panel/0.7/getting_started.md
@@ -93,7 +93,16 @@ Now that all of the files have been downloaded we need to configure some core as
 
 ::: tip Database Configuration
 You will need a database setup and a user with the correct permissions created for that database before
-continuing any further. If you are unsure how to do this, please have a look at [Setting up MySQL](/tutorials/mysql_setup.html).
+continuing any further. See below to quickly create a user and database for your Pterodactyl panel, if you are unsure how to do this or want more information, please have a look at [Setting up MySQL](/tutorials/mysql_setup.html).
+```
+$ mysql -u root -p
+
+mysql> CREATE USER 'pterodactyl'@'localhost' IDENTIFIED WITH mysql_native_password BY 'A secure password';
+mysql> CREATE DATABASE panel;
+mysql> GRANT ALL ON panel.* TO 'pterodactyl'@'localhost' WITH GRANT OPTION;
+mysql> FLUSH PRIVILEGES;
+
+```
 :::
 
 First we will copy over our default environment settings file, install core dependencies, and then generate a

--- a/tutorials/mysql_setup.md
+++ b/tutorials/mysql_setup.md
@@ -28,7 +28,7 @@ to `somePassword`.
 USE mysql;
 
 # Remember to change 'somePassword' below to be a unique password specific to this account.
-CREATE USER 'pterodactyl'@'127.0.0.1' IDENTIFIED BY 'somePassword';
+CREATE USER 'pterodactyl'@'127.0.0.1' IDENTIFIED WITH mysql_native_password BY 'somePassword';
 ```
 
 ### Create a database

--- a/tutorials/mysql_setup.md
+++ b/tutorials/mysql_setup.md
@@ -76,6 +76,13 @@ FLUSH PRIVILEGES;
 ### Allowing external database access
 Chances are you'll need to allow external access to this MySQL instance in order to allow servers to connect to it. To do this, open `my.cnf`, which varies in location depending on your OS and how MySQL was installed.
 
-Once opened, you'll want to change `bind-address=` to be `bind-address=0.0.0.0` which will allow connections on all interfaces, and thus, external connections.
+More recent versions of MySQL have moved the default configuration to `mysql.conf.d/mysqld.cnf` or for MariaDB installations the default configuration should be in `50-server.cnf`. *However*, `my.cnf` has been changed to update the default configurations so you don't edit your default configuration files (this is now considered bad practice)!
+
+If you open `my.cnf`, you'll want to add the lines:
+```
+[mysqld]
+bind-address=0.0.0.0
+```
+This will override the default MySQL configuration, which by default will only accept requests from lo. Updating this will allow connections on all interfaces, and thus, external connections.
 
 If your Node and Daemon are on the same machine, and you won't be needing external access, you can also use the `docker0` interface IP address, rather than `127.0.0.1`. This IP address can be found by running `ip addr | grep docker0`, and it likely looks something like `172.x.x.x`.


### PR DESCRIPTION
More recent versions of MariaDB/MySQL do not use mysql_native_password as the default authentication plugin.

This will result in an authentication error (unknown authentication type) when trying to connect to the host.

Edit:
Updated MySQL/Maria documentation since the usage of `my.cnf` has changed and the default configuration files have moved for both Maria (50-server.cnf) and MySQL (mysqld.cnf)