### PR TITLE
mysql_native_password and caching_sha2_password

### DIFF
--- a/tutorials/mysql_setup.md
+++ b/tutorials/mysql_setup.md
@@ -25,7 +25,7 @@ to our database. You can also use `%` as a wildcard or enter a numeric IP. We wi
 to `somePassword`.
 
 #### Later versions of Maria and MySQL (usually on latest versions of Debian distros)
-If you are using PHP 7.4+ then you should use the method for older vserions, as the default authentication method is correct! Laravel and PHP 7.4 can use the new caching_sha2_password authentication method.
+If you are using PHP 7.4+ then you should use the method for older versions, as the default authentication method is correct! Laravel and PHP 7.4 can use the new caching_sha2_password authentication method.
 
 ``` sql
 USE mysql;

--- a/tutorials/mysql_setup.md
+++ b/tutorials/mysql_setup.md
@@ -24,11 +24,25 @@ Next, we will create a user called `pterodactyl` and allow logins from localhost
 to our database. You can also use `%` as a wildcard or enter a numeric IP. We will also set the account password
 to `somePassword`.
 
+#### Later versions of Maria and MySQL (usually on latest versions of Debian distros)
+If you are using PHP 7.4+ then you should use the method for older vserions, as the default authentication method is correct! Laravel and PHP 7.4 can use the new caching_sha2_password authentication method.
+
 ``` sql
 USE mysql;
 
 # Remember to change 'somePassword' below to be a unique password specific to this account.
 CREATE USER 'pterodactyl'@'127.0.0.1' IDENTIFIED WITH mysql_native_password BY 'somePassword';
+```
+*mysql_native_password is the [classic authentication plugin](https://dba.stackexchange.com/questions/209514/what-is-mysql-native-password) for maria and mysql, this has been replaced by [caching_sha2_password](https://dev.mysql.com/doc/refman/8.0/en/caching-sha2-pluggable-authentication.html) but due to compatability issues with [laravel and older versions of PHP](https://laravel-news.com/laravel-and-mysql-8-fixing-mysql-server-has-gone-away-error) we cannot authenticate with this method. We need to use the classic authentication method.*
+
+If you have a problem with the above, try the old version below
+
+#### Older versions of Maria and MySQL **OR** PHP 7.4+ (Pre Deb 10/Ubuntu 19 and CentOS etc.)
+``` sql
+USE mysql;
+
+# Remember to change 'somePassword' below to be a unique password specific to this account.
+CREATE USER 'pterodactyl'@'127.0.0.1' IDENTIFIED BY 'somePassword';
 ```
 
 ### Create a database


### PR DESCRIPTION
mysql_native_password -> Not registered as an authentication plugin when it used to be the default, so should only be specified when caching_sha2_password is available else you'll get an error stating that mysql_native_password does not exist. Although if you are using a later version of MariaDB or MySQL and can't use caching_sha2_password you should specify this else you'll get an authentication error
caching_sha2_password -> Only supported by PHP 7.4+