### PR TITLE
Add warning to daemon page

### DIFF
--- a/daemon/0.6/installing.md
+++ b/daemon/0.6/installing.md
@@ -1,5 +1,8 @@
 # Installation
 
+::: warning
+Do not install this Daemon if you are using Pterodactyl 1.0 or higher! You will use [wings](/wings/1.0/installing.html) instead!
+
 [[toc]]
 
 ## Supported Systems

--- a/daemon/0.6/installing.md
+++ b/daemon/0.6/installing.md
@@ -1,7 +1,8 @@
 # Installation
 
 ::: warning
-Do not install this Daemon if you are using Pterodactyl 1.0 or higher! You will use [wings](/wings/1.0/installing.html) instead!
+This specific software is for Pterodactyl v0.7 and **must not be used for Pterodactyl v1.0**. If you have installed 1.0 you should use [Wings](/wings/1.0/installing.html) instead.
+:::
 
 [[toc]]
 


### PR DESCRIPTION
Add warning on the daemon install page so that new users know to only install wings with 1.0+

To be clear, I don't know exactly how this doc software works, so let me know if I did this wrong.