### PR TITLE
Remove Plural

### DIFF
--- a/panel/1.0/upgrade/1.0.md
+++ b/panel/1.0/upgrade/1.0.md
@@ -47,7 +47,7 @@ php artisan config:clear
 ```
 
 ## Database Updates
-You'll also need to update your database schema for the newest version of Pterodactyl. Running the two commands below
+You'll also need to update your database schema for the newest version of Pterodactyl. Running the command below
 will update the schema and ensure the default eggs we ship are up to date (and add any new ones we might have). Just
 remember, _never edit core eggs we ship_! They will be overwritten by this update process.
 


### PR DESCRIPTION
In https://github.com/pterodactyl/documentation/commit/c300dbe640e5fee5e14f27a1c5bd6334a4faf91f the other command was removed, it's observed that adding the `--force` does both of these commands. This simply updates the string to follow suit.