### PR TITLE
New way to use mysql_native_password

### DIFF
--- a/tutorials/mysql_setup.md
+++ b/tutorials/mysql_setup.md
@@ -28,7 +28,9 @@ to `somePassword`.
 USE mysql;
 
 # Remember to change 'somePassword' below to be a unique password specific to this account.
-CREATE USER 'pterodactyl'@'127.0.0.1' IDENTIFIED WITH mysql_native_password BY 'somePassword';
+# Use old_password=0 to use the native mysql password plugin
+SET old_password=0;
+CREATE USER 'pterodactyl'@'127.0.0.1' IDENTIFIED BY 'somePassword';
 ```
 
 ### Create a database


### PR DESCRIPTION
Newer versions of MariaDB (tested on `10.5.8-MariaDB-1:10.5.8+maria~focal`) seems to not understand the current syntax- I worked around the problem by following guide here: https://mariadb.com/kb/en/authentication-plugin-mysql_native_password/#creating-users

Can someone else confirm my findings before accepting the PR? 