### PR TITLE
Notice of being in the correct folder

### DIFF
--- a/panel/1.0/upgrade/0.7_to_1.0.md
+++ b/panel/1.0/upgrade/0.7_to_1.0.md
@@ -9,7 +9,7 @@ to be fully comitted to it.
 
 ## Enter Maintenance Mode
 You'll want to put your Panel into maintenance mode by running the `down` command below before starting. This
-will prevent users from accessing the Panel during a period where things will be broken or not working correctly.
+will prevent users from accessing the Panel during a period where things will be broken or not working correctly. Make sure that you're in the `/var/www/pterodactyl` directory when executing the command.
 
 ``` bash
 # Put the Panel into maintenance mode and deny user access


### PR DESCRIPTION
Users keep complaining about artisan errors because they're executing them in the wrong folder.

This adds a notice to inform them to perform these commands inside /var/www/pterodactyl