### PR TITLE
Specify 0.7 composer version

### DIFF
--- a/panel/0.7/getting_started.md
+++ b/panel/0.7/getting_started.md
@@ -65,7 +65,7 @@ Composer is a dependency manager for PHP that allows us to ship everything you'l
 need composer installed before continuing in this process.
 
 ``` bash
-curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer
+curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer --version=1.10.16
 ```
 
 ## Download Files


### PR DESCRIPTION
Been seeing many `undefined index: name` errors that could be quickly solved by adding this. yes, 0.7 deprecated, but there are many that install it anyway. let's save the headache. (inspiration from a pin in the discord)