### PR TITLE
remove certbot ppa

### DIFF
--- a/tutorials/creating_ssl_certificates.md
+++ b/tutorials/creating_ssl_certificates.md
@@ -7,9 +7,8 @@ cleaner creation of them. The command below is for Ubuntu distributions, but you
 site](https://certbot.eff.org/) for installation instructions.
                                                                                                                
 ``` bash
-sudo add-apt-repository ppa:certbot/certbot
 sudo apt update
-sudo apt install certbot
+sudo apt install -y certbot
 ```
 
 ### Creating a Certificate


### PR DESCRIPTION
the repository is not needed for 20.04 or 18.04 from what i see, and it doesnt work on 20.04 anyway.