### PR TITLE
Show versions separately :O

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -146,6 +146,7 @@ module.exports = {
                     currentVersion: '1.0',
                     versions: [
                         {
+                            title: "1.2",
                             name: '1.0',
                             status: 'stable',
                             children: [
@@ -164,6 +165,7 @@ module.exports = {
                     currentVersion: '1.0',
                     versions: [
                         {
+                            title: "1.2",
                             name: '1.0',
                             status: 'stable',
                             children: [

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -146,7 +146,7 @@ module.exports = {
                     currentVersion: '1.0',
                     versions: [
                         {
-                            title: "1.2",
+                            title: '1.2',
                             name: '1.0',
                             status: 'stable',
                             children: [
@@ -165,7 +165,7 @@ module.exports = {
                     currentVersion: '1.0',
                     versions: [
                         {
-                            title: "1.2",
+                            title: '1.2',
                             name: '1.0',
                             status: 'stable',
                             children: [

--- a/.vuepress/theme/VersionSelectItem.vue
+++ b/.vuepress/theme/VersionSelectItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="inline-block">
-    {{ version.name }}
+    {{ version.title || version.name }}
     <span class="rounded-full ml-2" :class="classes">{{version.status}}</span>
   </div>
 </template>


### PR DESCRIPTION
Make it so that wings and panel show 1.2 in the sidebar without destroying every link out there :)
Also made the old daemon collapsable so to minimize its footprint without outright removing it

as a side note:
package-lock.json changed... am I meant to include that?
gitpod also generated a .gitpod.yml, wasn't sure if I should include that either, so I left them out for now. can add the changes if asked