### PR TITLE
Add Next Step to getting started

### DIFF
--- a/panel/0.7/getting_started.md
+++ b/panel/0.7/getting_started.md
@@ -224,3 +224,5 @@ Finally, enable the service and set it to boot on machine start.
 ``` bash
 sudo systemctl enable --now pteroq.service
 ```
+
+#### Next Step: [Webserver Configuration](./webserver_configuration)

--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -225,3 +225,5 @@ Finally, enable the service and set it to boot on machine start.
 ``` bash
 sudo systemctl enable --now pteroq.service
 ```
+
+#### Next Step: [Webserver Configuration](./webserver_configuration)


### PR DESCRIPTION
Fixes #210
Adds a link at the bottom of the getting started page for the panel (1.0 and 0.7) so dummies don't miss a necessary step.