### PR TITLE
Fix in links

### DIFF
--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -88,7 +88,7 @@ and then set the correct permissions on the `storage/` and `bootstrap/cache/` di
 allow us to store files as well as keep a speedy cache available to reduce load times.
 
 ``` bash
-curl -Lo panel.tar.gz https://github.com/pterodactyl/panel/releases/download/v1.2.1/panel.tar.gz
+curl -Lo panel.tar.gz https://github.com/pterodactyl/panel/releases/latest/download/panel.tar.gz
 tar -xzvf panel.tar.gz
 chmod -R 755 storage/* bootstrap/cache/
 ```

--- a/panel/1.0/upgrade/0.7_to_1.0.md
+++ b/panel/1.0/upgrade/0.7_to_1.0.md
@@ -49,7 +49,7 @@ are not always detected properly, so simply uppacking over this location will re
 ``` bash
 # Delete the app directory to ensure we start with a clean slate here. This will not affect any
 # of your settings or servers.
-curl -L -o panel.tar.gz https://github.com/pterodactyl/panel/releases/download/v1.2.1/panel.tar.gz
+curl -L -o panel.tar.gz https://github.com/pterodactyl/panel/releases/latest/download/panel.tar.gz
 rm -rf $(find app public resources -depth | head -n -1 | grep -Fv "$(tar -tf panel.tar.gz)")
 
 # Download the updated files and delete the archive file.

--- a/panel/1.0/upgrade/1.0.md
+++ b/panel/1.0/upgrade/1.0.md
@@ -18,7 +18,7 @@ into your current folder.
 :::
 
 ``` bash
-curl -L https://github.com/pterodactyl/panel/releases/download/v1.2.1/panel.tar.gz | tar -xzv
+curl -L https://github.com/pterodactyl/panel/releases/latest/download/panel.tar.gz | tar -xzv
 ```
 
 Once all of the files are downloaded we need to set the correct permissions on the cache and storage directories to avoid

--- a/wings/1.0/installing.md
+++ b/wings/1.0/installing.md
@@ -95,7 +95,7 @@ run the commands below which will create the base directory and download the win
 
 ``` bash
 mkdir -p /etc/pterodactyl
-curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/download/v1.2.2/wings_linux_amd64
+curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_amd64
 chmod u+x /usr/local/bin/wings
 ```
 

--- a/wings/1.0/migrating.md
+++ b/wings/1.0/migrating.md
@@ -17,7 +17,7 @@ run the commands below which will create the base directory and download the win
 
 ``` bash
 mkdir -p /etc/pterodactyl
-curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/download/v1.2.2/wings_linux_amd64
+curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_amd64
 chmod u+x /usr/local/bin/wings
 ```
 

--- a/wings/1.0/upgrading.md
+++ b/wings/1.0/upgrading.md
@@ -9,7 +9,7 @@ First, download the updated wings binary into `/usr/local/bin`.
 :::
 
 ``` bash
-curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/download/v1.2.2/wings_linux_amd64
+curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_amd64
 chmod u+x /usr/local/bin/wings
 ```
 


### PR DESCRIPTION
Instead of using the version in the link use latest, makes it easier for those who use scripts to install/update panel/wings