### PR TITLE
Add alternative command for creating a MySQL user

### DIFF
--- a/tutorials/mysql_setup.md
+++ b/tutorials/mysql_setup.md
@@ -29,6 +29,9 @@ USE mysql;
 
 # Remember to change 'somePassword' below to be a unique password specific to this account.
 CREATE USER 'pterodactyl'@'127.0.0.1' IDENTIFIED WITH mysql_native_password BY 'somePassword';
+
+# If you get an error with "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version..", use the line below.
+CREATE USER 'pterodactyl'@'127.0.0.1' IDENTIFIED BY 'somePassword';
 ```
 
 ### Create a database


### PR DESCRIPTION
Show users the alternative command to create a user in MySQL if a syntax error is thrown for using "mysql_native_password", but retain the original command for users that have the module.