### PR TITLE
Fix "Only for 0.7 panel" warning in the "Create theme" section

### DIFF
--- a/community/tutorials/custom_theme_setup.md
+++ b/community/tutorials/custom_theme_setup.md
@@ -1,8 +1,7 @@
 # Creating a theme for Pterodactyl
 This tutorial briefly covers how to create a theme for Pterodactyl without overwriting the main theme files.
 
-:::warn
-The theming system has not been ported to 1.0+. This guide is only applicable to 0.7.X.
+::: warning The theming system has not been ported to 1.0+. This guide is only applicable to 0.7.X.
 :::
 
 ## Using CLI


### PR DESCRIPTION
The warning wasn't showing as a box in the documentation, it's just showing this:
:::warn The theming system has not been ported to 1.0+. This guide is only applicable to 0.7.X. :::

Here is a screenshot what it is showing:
![What it was showing](https://i.ibb.co/wSrcNLp/img.png)

Here is a screenshot what it should show:
![What it should show](https://i.ibb.co/dQW27Rc/img2.png)

It should look like this so people don't try this on the panel v1.x and then complain about it not working in the discord.