### PR TITLE
Fix cmdtest being installed instead of yarn

### DIFF
--- a/community/customization/panel.md
+++ b/community/customization/panel.md
@@ -17,11 +17,11 @@ The build tools require NodeJS, yarn is used as the package manager.
 
 ```bash
 # Ubuntu/Debian
-curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-apt install -y nodejs yarn
+curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+apt install -y nodejs
 
 # CentOS
-curl -sL https://rpm.nodesource.com/setup_12.x | sudo -E bash -
+curl -sL https://rpm.nodesource.com/setup_14.x | sudo -E bash -
 sudo yum install -y nodejs yarn # CentOS 7
 sudo dnf install -y nodejs yarn # CentOS 8
 ```
@@ -29,6 +29,8 @@ sudo dnf install -y nodejs yarn # CentOS 8
 Install required javascript packages.
 
 ```bash
+npm i -g yarn # Install Yarn
+
 cd /var/www/pterodactyl
 yarn # Installs panel build dependencies
 ```
@@ -41,3 +43,5 @@ The following command will rebuild the Panel frontend.
 cd /var/www/pterodactyl
 yarn build:production # Build panel
 ```
+
+You can use command `yarn run watch` to view the progress of your changes in almost real-time for easier development. Once you're satisfied with your changes build the panel using the previously mentioned `yarn build:production` command. 


### PR DESCRIPTION
The default yarn package installation on Debian will install test scenario cmdtest instead of yarn. Using npm for the installation ensures that the actual yarn is installed, alternatively, the source list could be added for the package installer, but npm is more user-friendly. A lot of users have encountered this issue in the Discord server.

Also, increased the nodejs install version to 14, but could revert it if required.