### PR TITLE
Changed SQL command to create user.

### DIFF
--- a/tutorials/mysql_setup.md
+++ b/tutorials/mysql_setup.md
@@ -28,7 +28,7 @@ to `somePassword`.
 USE mysql;
 
 # Remember to change 'somePassword' below to be a unique password specific to this account.
-CREATE USER 'pterodactyl'@'127.0.0.1' IDENTIFIED WITH mysql_native_password BY 'somePassword';
+CREATE USER 'pterodactyl'@'127.0.0.1' IDENTIFIED BY 'somePassword';
 ```
 
 ### Create a database


### PR DESCRIPTION
`WITH mysql_native_password` is no longer required in MariaDB/MySQL to create the user and returns an error when executed.