### PR TITLE
Fixed a typo

### DIFF
--- a/guides/php_upgrade.md
+++ b/guides/php_upgrade.md
@@ -51,7 +51,7 @@ Run the commands below to disable PHP 7.4 and enable PHP 8.0 when serving reques
 PHP 7.4 change the value in the command below to reflect that.
 
 ``` bash
-# Hint: a2dismod = a2_enable_module 🤯
+# Hint: a2enmod = a2_enable_module 🤯
 a2enmod php8.0
 
 # Hint: a2dismod = a2_disable_module 🤯


### PR DESCRIPTION
Fixed a typo, line 54: `a2enmod` was referring to a2dismod in the comment, which is incorrect.