### PR TITLE
Change the base docs to 20.04

### DIFF
--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -24,8 +24,8 @@ this software on an OpenVZ based system you will &mdash; most likely &mdash; not
 
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
-| **Ubuntu** | 18.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
-| | 20.04 | :white_check_mark: | |
+| **Ubuntu** | 18.04 | :white_check_mark: | Extra repos are required. |
+| | 20.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
 | **CentOS** | 7 | :white_check_mark: | Extra repos are required. |
 | | 8 | :white_check_mark: | |
 | **Debian** | 9 | :white_check_mark: | Extra repos are required. |
@@ -57,9 +57,6 @@ curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash
 
 # Update repositories list
 apt update
-
-# Add universe repository if you are on Ubuntu 18.04
-apt-add-repository universe
 
 # Install Dependencies
 apt -y install php8.0 php8.0-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip} mariadb-server nginx tar unzip git redis-server

--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -25,7 +25,7 @@ this software on an OpenVZ based system you will &mdash; most likely &mdash; not
 | Operating System | Version | Supported | Notes |
 | ---------------- | ------- | :-------: | ----- |
 | **Ubuntu** | 18.04 | :white_check_mark: | Extra repos are required. |
-| | 20.04 | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
+| | 20.04 | :white_check_mark: | Documentation written assuming Ubuntu 20.04 as the base OS. |
 | **CentOS** | 7 | :white_check_mark: | Extra repos are required. |
 | | 8 | :white_check_mark: | |
 | **Debian** | 9 | :white_check_mark: | Extra repos are required. |


### PR DESCRIPTION
Changed the table to show that 20.04 is the base OS that the documentation is written in.
Most people now are using the newer Ubuntu 20.04 OS, meaning the docs should also be where most people who are installing for the first time are using.