### PR TITLE
Changed daemon references to wings

### DIFF
--- a/community/config/nodes/add_node.md
+++ b/community/config/nodes/add_node.md
@@ -43,9 +43,9 @@ Don't forget to account for OS overhead and other software requirements on machi
 * **Daemon SFTP Port**: the port the Daemon sftp-server or standalone SFTP server should listen on.
 
 ## Install the Daemon
-At this point you'll need to have the Daemon installed on your machine. Check out the [documentation](/wings/installing.md)
-for more information, or try one of the community guides for [CentOS](/community/installation-guides/wings/centos7.md),
-[Ubuntu](/community/installation-guides/wings/ubuntu1804.md), or [Debian](/community/installation-guides/wings/debian9.md).
+At this point you'll need to have the Daemon installed on your machine. Check out the [documentation](/wings/installing.html)
+for more information, or try one of the community guides for [CentOS](/community/installation-guides/wings/centos7.html),
+[Ubuntu](/community/installation-guides/wings/ubuntu1804.html), or [Debian](/community/installation-guides/wings/debian9.html).
 
 ## Configuring the Node
 Go to the Node Configuration page

--- a/community/config/nodes/add_node.md
+++ b/community/config/nodes/add_node.md
@@ -43,9 +43,9 @@ Don't forget to account for OS overhead and other software requirements on machi
 * **Daemon SFTP Port**: the port the Daemon sftp-server or standalone SFTP server should listen on.
 
 ## Install the Daemon
-At this point you'll need to have the Daemon installed on your machine. Check out the [documentation](/daemon/installing.md)
-for more information, or try one of the community guides for [CentOS](/community/installation-guides/daemon/centos7.md),
-[Ubuntu](/community/installation-guides/daemon/ubuntu1804.md), or [Debian](/community/installation-guides/daemon/debian9.md).
+At this point you'll need to have the Daemon installed on your machine. Check out the [documentation](/wings/installing.md)
+for more information, or try one of the community guides for [CentOS](/community/installation-guides/wings/centos7.md),
+[Ubuntu](/community/installation-guides/wings/ubuntu1804.md), or [Debian](/community/installation-guides/wings/debian9.md).
 
 ## Configuring the Node
 Go to the Node Configuration page


### PR DESCRIPTION
There were still links leading to 404 pages (old daemon tutorials). I have changed these to the wings equivalent.