### PR TITLE
Add PHP repository during PHP upgrade

### DIFF
--- a/guides/php_upgrade.md
+++ b/guides/php_upgrade.md
@@ -14,6 +14,8 @@ In order to install PHP 8.0, you will need to run the following command. Please 
 may have slightly different requirements for how this command is formatted.
 
 ```bash
+# Add additional repository for PHP
+add-apt-repository -y ppa:ondrej/php
 apt -y update
 apt -y install php8.0 php8.0-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip}
 ```


### PR DESCRIPTION
Users should have added this during their first installation of the panel, but based on so many errors from Discord, not everyone has done it.

This would reduce the unnecessary error posts on Discord about unable to locate PHP 8 packages.