### PR TITLE
Configure a stronger dependency on docker.service in the service file

### DIFF
--- a/wings/1.0/installing.md
+++ b/wings/1.0/installing.md
@@ -133,6 +133,8 @@ this. Place the contents below in a file called `wings.service` in the `/etc/sys
 [Unit]
 Description=Pterodactyl Wings Daemon
 After=docker.service
+Requires=docker.service
+PartOf=docker.service
 
 [Service]
 User=root


### PR DESCRIPTION
This commit ensures that the `wings.service` only ever runs when the `docker.service` runs. This is important as the wings daemon severely misbehaves when the docker daemon is not running.

`Requires` makes sure that when `wings.service` is started that `docker.service` is started as well.  
`PartOf` makes sure that when `docker.service` is stopped (for any reason) or restarted, the same happens to `wings.service`

This change is introduced as restarting the docker daemon (for example during an update of docker) causes the wings daemon to enter a broken state, that consumes high amount of CPU and doesn't properly interact with the containers anymore. It never recovers from that state by itself, even after the docker daemon comes back up again. Only way I've found to fix that is by restarting the wings daemon as well, which overall isn't a big deal in the first place. This just adds robostness to the system and preemptively prevents issues that inexperienced sysadmins might have trouble fixing.