### PR TITLE
add network_mode: host

### DIFF
--- a/wings/1.0/configuration.md
+++ b/wings/1.0/configuration.md
@@ -45,6 +45,7 @@ Changing network mode to `host` grants Pterodactyl direct access to all machine 
 docker:
   network:
     name: host
+    network_mode: host    
 ```
 
 After making changes, the following commands will stop the Wings, remove the Pterodactyl network, and start the Wings again. Run at your own risk.


### PR DESCRIPTION
Resolves errors about not finding the pterodactyl network after it's been changed to host.

 `Error response from daemon: network pterodactyl_nw not found`