### PR TITLE
Add Wings to the chronological next step

### DIFF
--- a/panel/1.0/webserver_configuration.md
+++ b/panel/1.0/webserver_configuration.md
@@ -86,4 +86,4 @@ systemctl restart apache2
 :::
 ::::
 
-#### Next Step: [Wings Installation](../../wings/./installing.md)
+#### Next Step: [Wings Installation](../../wings/installing.md)

--- a/panel/1.0/webserver_configuration.md
+++ b/panel/1.0/webserver_configuration.md
@@ -85,3 +85,5 @@ systemctl restart apache2
 
 :::
 ::::
+
+#### Next Step: [Wings Installation](../../wings/./installing.md)


### PR DESCRIPTION
Some users appear to be missing that you actually need to install Wings and not just the Panel. This would make it a complete flow of Panel installation > webserver configuration > Wings installation