### PR TITLE
Include check_permissions_on_boot in the additional configuration

### DIFF
--- a/wings/1.0/configuration.md
+++ b/wings/1.0/configuration.md
@@ -97,4 +97,5 @@ More commonly discussed values. View all Wings config values and explanations in
 | websocket_log_count        |      150      | The number of lines to display in the console                                                   |
 | detect_clean_exit_as_crash |     true      | Mark server as crashed if it's stopped without user interaction, e.g., not pressing stop button |
 | (crash detection) timeout  |      60       | Timeout between server crashes that will not cause the server to be automatically restarted     |
-| app_name                   |  "Pterodactyl" | Changes the name of the daemon, shown in the panel's game console                               |  
+| app_name                   | "Pterodactyl" | Changes the name of the daemon, shown in the panel's game console                               |
+| check_permissions_on_boot  |     true      | Check all file permissions on each boot. Disable this when you have a very large amount of files and the server startup is hanging on checking permissions|


### PR DESCRIPTION
Someone had an issue with startup hanging on checking permissions and wasn't able to find how to disable it