### PR TITLE
Fix url at the end of wings community guide

### DIFF
--- a/community/installation-guides/wings/centos7.md
+++ b/community/installation-guides/wings/centos7.md
@@ -37,4 +37,4 @@ firewall-cmd --reload
 ```
 
 ## Installing Wings
-Great, now all of the dependencies and firewall rules have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.md#installing-wings-1).
+Great, now all of the dependencies and firewall rules have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.html#enabling-swap).

--- a/community/installation-guides/wings/centos8.md
+++ b/community/installation-guides/wings/centos8.md
@@ -37,4 +37,4 @@ firewall-cmd --reload
 ```
 
 ## Installing Wings
-Great, now all of the dependencies and firewall rules have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.md#installing-wings-1).
+Great, now all of the dependencies and firewall rules have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.html#enabling-swap).

--- a/community/installation-guides/wings/debian10.md
+++ b/community/installation-guides/wings/debian10.md
@@ -32,4 +32,4 @@ systemctl start docker
 ```
 
 ## Installing Wings
-Great, now all of the dependencies have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.md#installing-wings-1).
+Great, now all of the dependencies have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.html#enabling-swap).

--- a/community/installation-guides/wings/debian9.md
+++ b/community/installation-guides/wings/debian9.md
@@ -32,4 +32,4 @@ systemctl start docker
 ```
 
 ## Installing Wings
-Great, now all of the dependencies have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.html#enabling-swa).
+Great, now all of the dependencies have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.html#enabling-swap).

--- a/community/installation-guides/wings/debian9.md
+++ b/community/installation-guides/wings/debian9.md
@@ -32,4 +32,4 @@ systemctl start docker
 ```
 
 ## Installing Wings
-Great, now all of the dependencies have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.md#installing-wings-2).
+Great, now all of the dependencies have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.html#enabling-swap).

--- a/community/installation-guides/wings/debian9.md
+++ b/community/installation-guides/wings/debian9.md
@@ -32,4 +32,4 @@ systemctl start docker
 ```
 
 ## Installing Wings
-Great, now all of the dependencies have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.html#enabling-swap).
+Great, now all of the dependencies have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.html#enabling-swa).

--- a/community/installation-guides/wings/ubuntu1804.md
+++ b/community/installation-guides/wings/ubuntu1804.md
@@ -22,4 +22,4 @@ systemctl start docker
 ```
 
 ## Installing Wings
-Great, now all of the dependencies and firewall rules have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.md#installing-wings-1).
+Great, now all of the dependencies and firewall rules have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.html#enabling-swap).

--- a/community/installation-guides/wings/ubuntu2004.md
+++ b/community/installation-guides/wings/ubuntu2004.md
@@ -22,4 +22,4 @@ systemctl start docker
 ```
 
 ## Installing Wings
-Great, now all of the dependencies and firewall rules have been dealt with. From here follow the [official Wings installation documentation](/wings/installing.md#installing-wings-2).
+Great, now all of the dependencies and firewall rules have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.html#enabling-swap).


### PR DESCRIPTION
All of the wings community guides don't have the correct link at the end.