### PR TITLE
Added restart delay for pteroq and wings service

### DIFF
--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -196,6 +196,9 @@ User=www-data
 Group=www-data
 Restart=always
 ExecStart=/usr/bin/php /var/www/pterodactyl/artisan queue:work --queue=high,standard,low --sleep=3 --tries=3
+StartLimitInterval=180
+StartLimitBurst=30
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/wings/1.0/installing.md
+++ b/wings/1.0/installing.md
@@ -157,7 +157,9 @@ LimitNOFILE=4096
 PIDFile=/var/run/wings/daemon.pid
 ExecStart=/usr/local/bin/wings
 Restart=on-failure
-StartLimitInterval=600
+StartLimitInterval=180
+StartLimitBurst=30
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
There is a chance, that e.g. the database server of the system is not yet running after any reboot. Without the `RestartSec=` option systemd will restart the service with an delay of just `100ms` for `DefaultStartLimitBurst` in an interval of `DefaultStartLimitIntervalSec`. This may also fail as the database could take a little bit longer. In that case the startup of the service is aborted and the queue worker dies silently.

Using this option (set to `30s`) should slow down this behavior and also prevent systemd of giving the service up.

I've also extended the wings service, as it seems also to be affected slow database startups (when the respective host is simultaneously (re-)starting).