### PR TITLE
Update debian9.md

### DIFF
--- a/community/installation-guides/panel/debian9.md
+++ b/community/installation-guides/panel/debian9.md
@@ -12,7 +12,9 @@ We will first begin by installing all of Pterodactyl's [required](/panel/1.0/get
 
 ### MariaDB
 ```bash
+## Install the MariaDB repo for debian
 apt install -y software-properties-common dirmngr
+curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash
 
 ## Get apt updates
 apt update


### PR DESCRIPTION
Fixes an issue where it will automatically install MariaDB 10.1 (Which is not supported, 10.2 is lowest supported version).