### PR TITLE
Revert "Add instructions for downloading Wings for ARM"

### DIFF
--- a/wings/1.0/installing.md
+++ b/wings/1.0/installing.md
@@ -102,27 +102,11 @@ GRUB_CMDLINE_LINUX_DEFAULT="swapaccount=1"
 The first step for installing Wings is to make sure we have the required directory structure setup. To do so,
 run the commands below which will create the base directory and download the wings executable.
 
-:::: tabs
-::: tab "Normal Install"
-
-``` bash
+```bash
 mkdir -p /etc/pterodactyl
 curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_amd64
 chmod u+x /usr/local/bin/wings
 ```
-
-:::
-::: tab "ARM64 Install"
-If you are using an AArch64/ARM64 CPU, download the ARM64 Wings executable instead by running these commands. Be aware that you will need Docker Images built for ARM64, or your servers will not work.
-
-```bash
-mkdir -p /etc/pterodactyl
-curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_arm64
-chmod u+x /usr/local/bin/wings
-```
-
-:::
-::::
 
 ::: warning OVH/SYS Servers
 If you are using a server provided by OVH or SoYouStart please be aware that your main drive space is probably allocated to

--- a/wings/1.0/upgrading.md
+++ b/wings/1.0/upgrading.md
@@ -17,25 +17,10 @@ most cases your base Wings version should match that of your Panel.
 ## Download Updated Binary
 First, download the updated wings binary into `/usr/local/bin`.
 
-:::: tabs
-::: tab "Normal Upgrade"
-
 ``` bash
 curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_amd64
 chmod u+x /usr/local/bin/wings
 ```
-
-:::
-::: tab "ARM64 Upgrade"
-When using an AArch64/ARM64 CPU, download the ARM64 Wings executable with the commands below.
-
-```bash
-curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_arm64
-chmod u+x /usr/local/bin/wings
-```
-
-:::
-::::
 
 ## Restart Process
 Finally, restart the wings process. Your running servers will not be affected and any open


### PR DESCRIPTION
Reverts pterodactyl/documentation#383

The tabs are not always working properly on the Wings install page (only the install page, not the upgrade or others). Sometimes it fails to render, causing the instructions to disappear. I will revert the change until I can sit and debug it to see why the hydration process fails.