### PR TITLE
docs(s3): add aws_use_path_style_endpoint

### DIFF
--- a/panel/1.0/additional_configuration.md
+++ b/panel/1.0/additional_configuration.md
@@ -39,6 +39,7 @@ AWS_SECRET_ACCESS_KEY=
 AWS_BACKUPS_BUCKET=
 AWS_ENDPOINT=
 ```
+For some configurations, you might have to change your S3 URL from `bucket.domain.com` to `domain.com/bucket`. To accomplish this, add `AWS_USE_PATH_STYLE_ENDPOINT=true` to your `.env` file.
 
 ## reCAPTCHA
 
@@ -50,7 +51,7 @@ While we provide a global Site Key and Secret Key by default, we highly recommen
 
 You can generate your own keys in the [reCAPTCHA Admin Console](https://www.google.com/recaptcha/admin).
 
-The keys can then be applied using the Settings in the admin panel. The reCAPTCHA settings can be found on the **Advanced** 
+The keys can then be applied using the Settings in the admin panel. The reCAPTCHA settings can be found on the **Advanced** tab.
 
 ### Disabling reCAPTCHA
 


### PR DESCRIPTION
Specific configurations, such as dual-stacks or "older URLs" like minio, might require path style with the bucket being in the file path.