### PR TITLE
acme.sh command is wrong and doesn't work with DNS

### DIFF
--- a/tutorials/creating_ssl_certificates.md
+++ b/tutorials/creating_ssl_certificates.md
@@ -93,7 +93,7 @@ export CF_Email="Your_CloudFlare_Account@example.com"
 Then create the certificate.
 
 ```bash
-acme.sh --issue --standalone -d "example.com" --dns dns_cf \
+acme.sh --issue --dns dns_cf -d "example.com" \
 --key-file /etc/letsencrypt/live/example.com/privkey.pem \
 --fullchain-file /etc/letsencrypt/live/example.com/fullchain.pem 
 ```


### PR DESCRIPTION
The row "acme.sh --issue --standalone -d "example.com" --dns dns_cf \" should be changed to "acme.sh --issue --dns dns_cf -d "example.com" \" otherwise it wont use DNS and it will require port 80 to be open.