### PR TITLE
Explicitly tell to delete default webserver config

### DIFF
--- a/panel/1.0/webserver_configuration.md
+++ b/panel/1.0/webserver_configuration.md
@@ -1,23 +1,17 @@
 # Webserver Configuration
 
-## Removing the default configuration
-First of all you should remove the default Apache or NGINX configuration as it will expose application secrets to malicious users by default.
-``` bash
-# If using NGINX:
-rm /etc/nginx/sites-available/default && rm /etc/nginx/sites-enabled/default
-
-# If using Apache:
-rm /etc/apache2/sites-enabled 000-default.conf 
-```
-
-## Creating Pterodactyl configuration
 ::: warning
 When using the SSL configuration you MUST create SSL certificates, otherwise your webserver will fail to start. See the [Creating SSL Certificates](/tutorials/creating_ssl_certificates.html) documentation page to learn how to create these certificates before continuing.
 :::
 
 :::: tabs
 ::: tab "Nginx With SSL"
-You should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
+First, remove the default NGINX configuration.
+``` bash
+rm /etc/nginx/sites-enabled/default
+```
+
+Now you should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
 `pterodactyl.conf` and place it in `/etc/nginx/sites-available/`, or &mdash; if on CentOS, `/etc/nginx/conf.d/`.
 
 <<< @/.snippets/webservers/nginx-php8.0.conf{5,11,26-27}
@@ -35,7 +29,12 @@ systemctl restart nginx
 
 :::
 ::: tab "Nginx Without SSL"
-You should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
+First, remove the default NGINX configuration.
+``` bash
+rm /etc/nginx/sites-enabled/default
+```
+
+Now you should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
 `pterodactyl.conf` and place it in `/etc/nginx/sites-available/`, or &mdash; if on CentOS, `/etc/nginx/conf.d/`.
 
 <<< @/.snippets/webservers/nginx-php8.0-nossl.conf{3}
@@ -53,7 +52,12 @@ systemctl restart nginx
 
 :::
 ::: tab "Apache With SSL"
-You should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
+First, remove the default Apache configuration.
+``` bash
+a2dissite 000-default.conf
+```
+
+Now you should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
 `pterodactyl.conf` and place it in `/etc/apache2/sites-available`, or &mdash; if on CentOS, `/etc/httpd/conf.d/`.
 
 Note: When using Apache, make sure you have the `libapache2-mod-php` package installed or else PHP will not display on your webserver.
@@ -73,7 +77,12 @@ systemctl restart apache2
 
 :::
 ::: tab "Apache Without SSL"
-You should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
+First, remove the default Apache configuration.
+``` bash
+a2dissite 000-default.conf
+```
+
+Now you should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
 `pterodactyl.conf` and place it in `/etc/apache2/sites-available`, or &mdash; if on CentOS, `/etc/httpd/conf.d/`.
 
 Note: When using Apache, make sure you have the `libapache2-mod-php` package installed or else PHP will not display on your webserver.

--- a/panel/1.0/webserver_configuration.md
+++ b/panel/1.0/webserver_configuration.md
@@ -1,8 +1,16 @@
 # Webserver Configuration
 
-::: danger
-You should remove the default Apache or NGINX configuration as it will expose application secrets to malicious users by default.
-:::
+## Removing the default configuration
+First of all you should remove the default Apache or NGINX configuration as it will expose application secrets to malicious users by default.
+``` bash
+# If using NGINX:
+rm /etc/nginx/sites-available/default && rm /etc/nginx/sites-enabled/default
+
+# If using Apache:
+rm /etc/apache2/sites-enabled 000-default.conf 
+```
+
+## Creating Pterodactyl configuration
 ::: warning
 When using the SSL configuration you MUST create SSL certificates, otherwise your webserver will fail to start. See the [Creating SSL Certificates](/tutorials/creating_ssl_certificates.html) documentation page to learn how to create these certificates before continuing.
 :::
@@ -13,7 +21,6 @@ You should paste the contents of the file below, replacing `<domain>` with your 
 `pterodactyl.conf` and place it in `/etc/nginx/sites-available/`, or &mdash; if on CentOS, `/etc/nginx/conf.d/`.
 
 <<< @/.snippets/webservers/nginx-php8.0.conf{5,11,26-27}
-
 ### Enabling Configuration
 
 The final step is to enable your NGINX configuration and restart it.


### PR DESCRIPTION
Many users forget to delete the default config and then ask on the Discord for help. Seems like the big red "DANGER" at the top isn't explicit enough.