### PR TITLE
docs(wings): Display ARM64 download for wings

### DIFF
--- a/wings/1.0/installing.md
+++ b/wings/1.0/installing.md
@@ -102,14 +102,16 @@ Some Linux distros may ignore `GRUB_CMDLINE_LINUX_DEFAULT`. Therefore you might 
 The first step for installing Wings is to make sure we have the required directory structure setup. To do so,
 run the commands below which will create the base directory and download the wings executable.
 
+### For AMD64:
 ```bash
 mkdir -p /etc/pterodactyl
-
-# For AMD64 use:
 curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_amd64
-# For ARM64/AARCH64 use:
+chmod u+x /usr/local/bin/wings
+```
+### For ARM64/AARCH64:
+```bash
+mkdir -p /etc/pterodactyl
 curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_arm64
-
 chmod u+x /usr/local/bin/wings
 ```
 

--- a/wings/1.0/installing.md
+++ b/wings/1.0/installing.md
@@ -9,6 +9,7 @@ for previous versions of Pterodactyl.
 :::
 
 ## Supported Systems
+
 The following is a list of supported operating systems. Please be aware that this is not an exhaustive list,
 there is a high probability that you can run the software on other Linux distributions without much effort.
 You are responsible for determining which packages may be necessary on those systems. There is also a very
@@ -102,13 +103,16 @@ Some Linux distros may ignore `GRUB_CMDLINE_LINUX_DEFAULT`. Therefore you might 
 The first step for installing Wings is to make sure we have the required directory structure setup. To do so,
 run the commands below which will create the base directory and download the wings executable.
 
-### For AMD64:
+### For AMD64
+
 ```bash
 mkdir -p /etc/pterodactyl
 curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_amd64
 chmod u+x /usr/local/bin/wings
 ```
-### For ARM64/AARCH64:
+
+### For ARM64/AARCH64
+
 ```bash
 mkdir -p /etc/pterodactyl
 curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_arm64

--- a/wings/1.0/installing.md
+++ b/wings/1.0/installing.md
@@ -104,7 +104,12 @@ run the commands below which will create the base directory and download the win
 
 ```bash
 mkdir -p /etc/pterodactyl
+
+# For AMD64 use:
 curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_amd64
+# For ARM64/AARCH64 use:
+curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_arm64
+
 chmod u+x /usr/local/bin/wings
 ```
 

--- a/wings/1.0/upgrading.md
+++ b/wings/1.0/upgrading.md
@@ -20,7 +20,11 @@ most cases your base Wings version should match that of your Panel.
 First, download the updated wings binary into `/usr/local/bin`.
 
 ``` bash
+# For AMD64 use:
 curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_amd64
+# For ARM64/AARCH64 use:
+curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_arm64
+
 chmod u+x /usr/local/bin/wings
 ```
 

--- a/wings/1.0/upgrading.md
+++ b/wings/1.0/upgrading.md
@@ -19,12 +19,14 @@ most cases your base Wings version should match that of your Panel.
 ## Download Updated Binary
 First, download the updated wings binary into `/usr/local/bin`.
 
-``` bash
-# For AMD64 use:
+### For AMD64:
+```bash
 curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_amd64
-# For ARM64/AARCH64 use:
+chmod u+x /usr/local/bin/wings
+```
+### For ARM64/AARCH64:
+```bash
 curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_arm64
-
 chmod u+x /usr/local/bin/wings
 ```
 

--- a/wings/1.0/upgrading.md
+++ b/wings/1.0/upgrading.md
@@ -1,7 +1,9 @@
 # Upgrading Wings
+
 Upgrading Wings is a painless process and should take less than a minute to complete.
 
 ## Wings Version Requirements
+
 Each version of Pterodactyl Panel also has a corresponding minimum version of Wings that
 is required for it to run. Please see the chart below for how these versions line up. In
 most cases your base Wings version should match that of your Panel.
@@ -17,20 +19,25 @@ most cases your base Wings version should match that of your Panel.
 | **1.6.x**     | **1.5.x**     | ✅        |
 
 ## Download Updated Binary
+
 First, download the updated wings binary into `/usr/local/bin`.
 
-### For AMD64:
+### For AMD64
+
 ```bash
 curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_amd64
 chmod u+x /usr/local/bin/wings
 ```
-### For ARM64/AARCH64:
+
+### For ARM64/AARCH64
+
 ```bash
 curl -L -o /usr/local/bin/wings https://github.com/pterodactyl/wings/releases/latest/download/wings_linux_arm64
 chmod u+x /usr/local/bin/wings
 ```
 
 ## Restart Process
+
 Finally, restart the wings process. Your running servers will not be affected and any open
 connections to the instance will re-connect automatically.
 


### PR DESCRIPTION
Often people with arm64 don't realize that they have to download the arm variant of wings because it is nowhere noted.