### PR TITLE
Permissions and removal of the archive

### DIFF
--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -107,9 +107,9 @@ please have a look at [Setting up MySQL](/tutorials/mysql_setup.html).
 mysql -u root -p
 
 # Remember to change 'yourPassword' below to be a unique password
-CREATE USER 'pterodactyl'@'127.0.0.1' IDENTIFIED BY 'yourPassword';
+CREATE USER 'pterodactyl'@'localhostr' IDENTIFIED BY 'yourPassword';
 CREATE DATABASE panel;
-GRANT ALL PRIVILEGES ON panel.* TO 'pterodactyl'@'127.0.0.1' WITH GRANT OPTION;
+GRANT ALL PRIVILEGES ON panel.* TO 'pterodactyl'@'localhost' WITH GRANT OPTION;
 exit
 ```
 

--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -90,7 +90,8 @@ allow us to store files as well as keep a speedy cache available to reduce load 
 ``` bash
 curl -Lo panel.tar.gz https://github.com/pterodactyl/panel/releases/latest/download/panel.tar.gz
 tar -xzvf panel.tar.gz
-chmod -R 755 storage/* bootstrap/cache/
+chmod -R 755 .
+rm -r panel.tar.gz
 ```
 
 ## Installation


### PR DESCRIPTION
Better to use 755 on the entire directory, in addition, it would be unnecessary to leave the .tar.gz archive lying around!