### PR TITLE
Update remi & use php 8 on CentOS

### DIFF
--- a/community/installation-guides/panel/centos7.md
+++ b/community/installation-guides/panel/centos7.md
@@ -45,7 +45,7 @@ systemctl start mariadb
 systemctl enable mariadb
 ```
 
-### PHP 7.4
+### PHP 8.0
 We recommend the remi repo to get the latest php packages.
 
 ```bash

--- a/community/installation-guides/panel/centos7.md
+++ b/community/installation-guides/panel/centos7.md
@@ -58,7 +58,7 @@ yum-config-manager --enable remi-php80
 ## Get yum updates
 yum update -y
 
-## Install PHP 7.4
+## Install PHP 8.0
 yum install -y php php-{common,fpm,cli,json,mysqlnd,mcrypt,gd,mbstring,pdo,zip,bcmath,dom,opcache}
 ```
 

--- a/community/installation-guides/panel/centos7.md
+++ b/community/installation-guides/panel/centos7.md
@@ -50,10 +50,10 @@ We recommend the remi repo to get the latest php packages.
 
 ```bash
 ## Install Repos
-yum install -y epel-release http://rpms.remirepo.net/enterprise/remi-release-7.rpm
+yum install -y epel-release http://rpms.remirepo.net/enterprise/remi-release-8.rpm
 yum install -y yum-utils
 yum-config-manager --disable remi-php54
-yum-config-manager --enable remi-php74
+yum-config-manager --enable remi-php80
 
 ## Get yum updates
 yum update -y

--- a/community/installation-guides/panel/centos8.md
+++ b/community/installation-guides/panel/centos8.md
@@ -28,7 +28,7 @@ systemctl start mariadb
 systemctl enable mariadb
 ```
 
-### PHP 7.4
+### PHP 8.0
 We recommend the remi repo to get the latest php packages.
 
 ```bash

--- a/community/installation-guides/panel/centos8.md
+++ b/community/installation-guides/panel/centos8.md
@@ -34,13 +34,13 @@ We recommend the remi repo to get the latest php packages.
 ```bash
 ## Install Repos
 dnf install epel-release
-dnf install https://rpms.remirepo.net/enterprise/remi-release-9.rpm
+dnf install https://rpms.remirepo.net/enterprise/remi-release-8.rpm
 dnf module enable php:remi-8.0
 
 ## Get dnf updates
 dnf update -y
 
-## Install PHP 7.4
+## Install PHP 8.0
 dnf install -y php php-{common,fpm,cli,json,mysqlnd,gd,mbstring,pdo,zip,bcmath,dom,opcache}
 ```
 

--- a/community/installation-guides/panel/centos8.md
+++ b/community/installation-guides/panel/centos8.md
@@ -34,8 +34,8 @@ We recommend the remi repo to get the latest php packages.
 ```bash
 ## Install Repos
 dnf install epel-release
-dnf install https://rpms.remirepo.net/enterprise/remi-release-8.rpm
-dnf module enable php:remi-7.4
+dnf install https://rpms.remirepo.net/enterprise/remi-release-9.rpm
+dnf module enable php:remi-8.0
 
 ## Get dnf updates
 dnf update -y

--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -28,7 +28,7 @@ this software on an OpenVZ based system you will &mdash; most likely &mdash; not
 | **Ubuntu**       | 18.04   | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
 |                  | 20.04   | :white_check_mark: |                                                             |
 | **CentOS**       | 7       | :white_check_mark: | Extra repos are required.                                   |
-|                  | 8       | :white_check_mark: |                                                             |
+|                  | 8       | :white_check_mark: | Note that CentOS 8 is EOL. Use Rocky or Alma Linux.         |
 | **Debian**       | 9       | :white_check_mark: | Extra repos are required.                                   |
 |                  | 10      | :white_check_mark: |                                                             |
 |                  | 11      | :white_check_mark: |                                                             |

--- a/wings/1.0/installing.md
+++ b/wings/1.0/installing.md
@@ -21,7 +21,7 @@ only the versions listed below.
 | **Ubuntu**       | 18.04   | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
 |                  | 20.04   | :white_check_mark: |                                                             |
 | **CentOS**       | 7       | :white_check_mark: |                                                             |
-|                  | 8       | :white_check_mark: |                                                             |
+|                  | 8       | :white_check_mark: | Note that CentOS 8 is EOL. Use Rocky or Alma Linux.         |
 | **Debian**       | 9       | :white_check_mark: |                                                             |
 |                  | 10      | :white_check_mark: |                                                             |
 |                  | 11      | :white_check_mark: |                                                             |


### PR DESCRIPTION
Update Remi to 9 and use PHP 8.0

Also noted that CentOS 8 is EOL.