### PR TITLE
Ubuntu 20.04: command to add PPA for PHP 8

### DIFF
--- a/community/installation-guides/panel/ubuntu2004.md
+++ b/community/installation-guides/panel/ubuntu2004.md
@@ -25,6 +25,9 @@ systemctl enable mariadb
 
 ### PHP 8.0
 ```bash
+## Add the repo
+add-apt-repository ppa:ondrej/php
+
 ## Get apt updates
 apt update -y
 


### PR DESCRIPTION
This PPA is required to install PHP 8 on Ubuntu 20.04