### PR TITLE
docs: instruct to enable ssl module for apache

### DIFF
--- a/panel/1.0/webserver_configuration.md
+++ b/panel/1.0/webserver_configuration.md
@@ -72,6 +72,7 @@ below!_ You only need to run `systemctl restart httpd`.
 # You do not need to run any of these commands on CentOS
 sudo ln -s /etc/apache2/sites-available/pterodactyl.conf /etc/apache2/sites-enabled/pterodactyl.conf
 sudo a2enmod rewrite
+sudo a2enmod ssl
 sudo systemctl restart apache2
 ```
 


### PR DESCRIPTION
Running `a2enmod ssl` will prevent the following error that often people on the discord have:
`Invalid command 'SSLEngine', perhaps misspelled or defined by a module not included in the server configuration`