### PR TITLE
Update documentation for 1.8 release

### DIFF
--- a/.snippets/webservers/nginx-php8.1-nossl.conf
+++ b/.snippets/webservers/nginx-php8.1-nossl.conf
@@ -1,0 +1,46 @@
+server {
+    # Replace the example <domain> with your domain name or IP address
+    listen 80;
+    server_name <domain>;
+
+
+    root /var/www/pterodactyl/public;
+    index index.html index.htm index.php;
+    charset utf-8;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log  /var/log/nginx/pterodactyl.app-error.log error;
+
+    # allow larger file uploads and longer script runtimes
+    client_max_body_size 100m;
+    client_body_timeout 120s;
+
+    sendfile off;
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/run/php/php8.1-fpm.sock;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param PHP_VALUE "upload_max_filesize = 100M \n post_max_size=100M";
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param HTTP_PROXY "";
+        fastcgi_intercept_errors off;
+        fastcgi_buffer_size 16k;
+        fastcgi_buffers 4 16k;
+        fastcgi_connect_timeout 300;
+        fastcgi_send_timeout 300;
+        fastcgi_read_timeout 300;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/.snippets/webservers/nginx-php8.1.conf
+++ b/.snippets/webservers/nginx-php8.1.conf
@@ -1,0 +1,66 @@
+server_tokens off;
+
+server {
+    listen 80;
+    server_name <domain>;
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name <domain>;
+
+    root /var/www/pterodactyl/public;
+    index index.php;
+
+    access_log /var/log/nginx/pterodactyl.app-access.log;
+    error_log  /var/log/nginx/pterodactyl.app-error.log error;
+
+    # allow larger file uploads and longer script runtimes
+    client_max_body_size 100m;
+    client_body_timeout 120s;
+
+    sendfile off;
+
+    # SSL Configuration - Replace the example <domain> with your domain
+    ssl_certificate /etc/letsencrypt/live/<domain>/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/<domain>/privkey.pem;
+    ssl_session_cache shared:SSL:10m;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384";
+    ssl_prefer_server_ciphers on;
+
+    # See https://hstspreload.org/ before uncommenting the line below.
+    # add_header Strict-Transport-Security "max-age=15768000; preload;";
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Robots-Tag none;
+    add_header Content-Security-Policy "frame-ancestors 'self'";
+    add_header X-Frame-Options DENY;
+    add_header Referrer-Policy same-origin;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/run/php/php8.1-fpm.sock;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param PHP_VALUE "upload_max_filesize = 100M \n post_max_size=100M";
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param HTTP_PROXY "";
+        fastcgi_intercept_errors off;
+        fastcgi_buffer_size 16k;
+        fastcgi_buffers 4 16k;
+        fastcgi_connect_timeout 300;
+        fastcgi_send_timeout 300;
+        fastcgi_read_timeout 300;
+        include /etc/nginx/fastcgi_params;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -141,7 +141,7 @@ module.exports = {
                     currentVersion: '1.0',
                     versions: [
                         {
-                            title: '1.7',
+                            title: '1.8',
                             name: '1.0',
                             status: 'stable',
                             children: [

--- a/guides/php_upgrade.md
+++ b/guides/php_upgrade.md
@@ -41,7 +41,7 @@ is most likely called `pterodactyl.conf` and located in the `/etc/nginx/sites-av
 Make sure to update the path in the command below to reflect the actual location of your configuration file.
 
 ``` bash
-sed -i -e 's/php7.[0-4]-fpm.sock/php8.1-fpm.sock/' /etc/nginx/sites-available/pterodactyl.conf
+sed -i -e 's/php[7|8].[0-9]-fpm.sock/php8.1-fpm.sock/' /etc/nginx/sites-available/pterodactyl.conf
 ```
 
 Once you have edited the file run the command below to reload nginx and apply your changes.
@@ -52,15 +52,15 @@ systemctl reload nginx
 
 :::
 ::: tab "Apache"
-Run the commands below to disable PHP 7.4 and enable PHP 8.1 when serving requests. If you are upgrading from
-PHP 7.4 change the value in the command below to reflect that.
+Run the commands below to disable all previous PHP versions and enable PHP 8.1 when serving requests.
 
 ``` bash
+# Hint: a2dismod = a2_disable_module 🤯
+a2dismod php*
+
 # Hint: a2enmod = a2_enable_module 🤯
 a2enmod php8.1
 
-# Hint: a2dismod = a2_disable_module 🤯
-a2dismod php7.3
 ```
 
 :::

--- a/guides/php_upgrade.md
+++ b/guides/php_upgrade.md
@@ -3,21 +3,22 @@
 This documentation includes instructions for upgrading your system to the latest version of PHP. Please reference the
 table below to check what version you need for your version of Pterodactyl.
 
-| Panel Version | PHP Version  |
-| ------------- | ------------ |
-| 1.0.0 - 1.2.0 | 7.3, 7.4 |
-| 1.3.0+        | 7.4, 8.0 |
+| Panel Version | PHP Version   |
+| ------------- | ------------- |
+| 1.0.0 - 1.2.0 | 7.3, 7.4      |
+| 1.3.0+        | 7.4, 8.0      |
+| 1.8.0+        | 7.4, 8.0, 8.1 |
 
 ## Install PHP
 
-In order to install PHP 8.0, you will need to run the following command. Please keep in mind different operating systems
+In order to install PHP 8.1, you will need to run the following command. Please keep in mind different operating systems
 may have slightly different requirements for how this command is formatted.
 
 ```bash
 # Add additional repository for PHP
 add-apt-repository -y ppa:ondrej/php
 apt -y update
-apt -y install php8.0 php8.0-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip}
+apt -y install php8.1 php8.1-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip}
 ```
 
 ## Update Composer
@@ -33,33 +34,36 @@ composer self-update --2
 
 :::: tabs
 ::: tab "NGINX"
-After upgrading to PHP 8.0, you will most likely need to update your NGINX configuration. Your configuration file
+After upgrading to PHP 8.1, you will most likely need to update your NGINX configuration. Your configuration file
 is most likely called `pterodactyl.conf` and located in the `/etc/nginx/sites-available/` directory, or if on CentOS,
 `/etc/nginx/conf.d/`.
 
 Make sure to update the path in the command below to reflect the actual location of your configuration file.
+
 ``` bash
-sed -i -e 's/php7.[0-4]-fpm.sock/php8.0-fpm.sock/' /etc/nginx/sites-available/pterodactyl.conf
+sed -i -e 's/php7.[0-4]-fpm.sock/php8.1-fpm.sock/' /etc/nginx/sites-available/pterodactyl.conf
 ```
 
 Once you have edited the file run the command below to reload nginx and apply your changes.
+
 ```bash
 systemctl reload nginx
 ```
 
 :::
 ::: tab "Apache"
-Run the commands below to disable PHP 7.4 and enable PHP 8.0 when serving requests. If you are upgrading from
+Run the commands below to disable PHP 7.4 and enable PHP 8.1 when serving requests. If you are upgrading from
 PHP 7.4 change the value in the command below to reflect that.
 
 ``` bash
 # Hint: a2enmod = a2_enable_module 🤯
-a2enmod php8.0
+a2enmod php8.1
 
 # Hint: a2dismod = a2_disable_module 🤯
 a2dismod php7.3
 ```
+
 :::
 ::::
 
-#### [Return to the 1.X.X Upgrade Guide](/panel/1.0/upgrade/1.0.md#fetch-updated-files)
+### [Return to the 1.X.X Upgrade Guide](/panel/1.0/upgrade/1.0.md#fetch-updated-files)

--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -27,7 +27,7 @@ this software on an OpenVZ based system you will &mdash; most likely &mdash; not
 | ---------------- | ------- | :----------------: | ----------------------------------------------------------- |
 | **Ubuntu**       | 18.04   | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
 |                  | 20.04   | :white_check_mark: |                                                             |
-|                  | 22.04   | :white_check_mark: | MariaDB can be installed without the repo setup script.      |
+|                  | 22.04   | :white_check_mark: | MariaDB can be installed without the repo setup script.     |
 | **CentOS**       | 7       | :white_check_mark: | Extra repos are required.                                   |
 |                  | 8       | :white_check_mark: | Note that CentOS 8 is EOL. Use Rocky or Alma Linux.         |
 | **Debian**       | 9       | :white_check_mark: | Extra repos are required.                                   |

--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -27,6 +27,7 @@ this software on an OpenVZ based system you will &mdash; most likely &mdash; not
 | ---------------- | ------- | :----------------: | ----------------------------------------------------------- |
 | **Ubuntu**       | 18.04   | :white_check_mark: | Documentation written assuming Ubuntu 18.04 as the base OS. |
 |                  | 20.04   | :white_check_mark: |                                                             |
+|                  | 22.04   | :white_check_mark: | MariaDB can be installed without the repo setup script.      |
 | **CentOS**       | 7       | :white_check_mark: | Extra repos are required.                                   |
 |                  | 8       | :white_check_mark: | Note that CentOS 8 is EOL. Use Rocky or Alma Linux.         |
 | **Debian**       | 9       | :white_check_mark: | Extra repos are required.                                   |
@@ -35,8 +36,8 @@ this software on an OpenVZ based system you will &mdash; most likely &mdash; not
 
 ## Dependencies
 
-* PHP `7.4` or `8.0` (recommended) with the following extensions: `cli`, `openssl`, `gd`, `mysql`, `PDO`, `mbstring`, `tokenizer`, `bcmath`, `xml` or `dom`, `curl`, `zip`, and `fpm` if you are planning to use NGINX.
-* MySQL `5.7.22` or higher (MySQL `8` recommended) **or** MariaDB `10.2` or higher.
+* PHP `7.4`, `8.0` or `8.1` (recommended) with the following extensions: `cli`, `openssl`, `gd`, `mysql`, `PDO`, `mbstring`, `tokenizer`, `bcmath`, `xml` or `dom`, `curl`, `zip`, and `fpm` if you are planning to use NGINX.
+* MySQL `5.7.22` and higher (MySQL `8` recommended) **or** MariaDB `10.2` and higher.
 * Redis (`redis-server`)
 * A webserver (Apache, NGINX, Caddy, etc.)
 * `curl`
@@ -56,7 +57,9 @@ apt -y install software-properties-common curl apt-transport-https ca-certificat
 
 # Add additional repositories for PHP, Redis, and MariaDB
 LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php
-add-apt-repository -y ppa:chris-lea/redis-server
+add-apt-repository ppa:redislabs/redis -y
+
+# MariaDB repo setup script can be skipped on Ubuntu 22.04
 curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash
 
 # Update repositories list
@@ -66,7 +69,7 @@ apt update
 apt-add-repository universe
 
 # Install Dependencies
-apt -y install php8.0 php8.0-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip} mariadb-server nginx tar unzip git redis-server
+apt -y install php8.1 php8.1-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip} mariadb-server nginx tar unzip git redis-server
 ```
 
 ### Installing Composer

--- a/panel/1.0/legacy_upgrade.md
+++ b/panel/1.0/legacy_upgrade.md
@@ -16,7 +16,7 @@ php artisan down
 You'll need to make sure your system dependencies are up to date before performing this upgrade. Please
 reference the list below to ensure you have all of the required versions.
 
-* PHP `7.4` or `8.0` (recommended) with the following extensions: `cli`, `openssl`, `gd`, `mysql`, `PDO`, `mbstring`,
+* PHP `7.4`, `8.0` or `8.1` (recommended) with the following extensions: `cli`, `openssl`, `gd`, `mysql`, `PDO`, `mbstring`,
   `tokenizer`, `bcmath`, `xml` or `dom`, `curl`, `zip`, and `fpm` if you are planning to use nginx. See our guide
   for [Upgrading PHP](/guides/php_upgrade.md) for details.
 * Composer v2 (`composer self-update --2`)

--- a/panel/1.0/updating.md
+++ b/panel/1.0/updating.md
@@ -9,15 +9,17 @@ Each version of Pterodactyl Panel also has a corresponding minimum version of Wi
 is required for it to run. Please see the chart below for how these versions line up. In
 most cases your base Wings version should match that of your Panel.
 
-| Panel Version | Wings Version | Supported | PHP Versions |
-| ------------- | ------------- | --------- | ------------ |
-| 1.0.x         | 1.0.x         |           | 7.3, 7.4     |
-| 1.1.x         | 1.1.x         |           | 7.3, 7.4     |
-| 1.2.x         | 1.2.x         |           | 7.3, 7.4     |
-| 1.3.x         | 1.3.x         |           | 7.4, 8.0     |
-| 1.4.x         | 1.4.x         |           | 7.4, 8.0     |
-| 1.5.x         | 1.4.x         |           | 7.4, 8.0     |
-| **1.7.x**     | **1.5.x**     | ✅        | 7.4, 8.0     |
+| Panel Version | Wings Version | Supported | PHP Versions  |
+| ------------- | ------------- | --------- | ------------- |
+| 1.0.x         | 1.0.x         |           | 7.3, 7.4      |
+| 1.1.x         | 1.1.x         |           | 7.3, 7.4      |
+| 1.2.x         | 1.2.x         |           | 7.3, 7.4      |
+| 1.3.x         | 1.3.x         |           | 7.4, 8.0      |
+| 1.4.x         | 1.4.x         |           | 7.4, 8.0      |
+| 1.5.x         | 1.4.x         |           | 7.4, 8.0      |
+| 1.6.x         | 1.4.x         |           | 7.4, 8.0      |
+| 1.7.x         | 1.5.x         |           | 7.4, 8.0      |
+| **1.8.x**     | **1.6.x**     | ✅        | 7.4, 8.0, 8,1 |
 
 ## Update Dependencies
 
@@ -27,7 +29,7 @@ dependencies. The latest versions of Pterodactyl Panel require a **minimum versi
 Composer v2.
 :::
 
-* PHP `7.4` or `8.0` (recommended)
+* PHP `7.4`, `8.0` or `8.1` (recommended)
 * Composer `2.X`
 
 Previous versions of Pterodactyl allowed for you to be running PHP 7.3. However, due to dependency updates and
@@ -40,13 +42,13 @@ our [PHP Upgrade Guide](/guides/php_upgrade.md) and return to this documentation
 
 ```
 vagrant@pterodactyl:~/app$ php -v
-PHP 8.0.1 (cli) (built: Jan 13 2021 08:22:35) ( NTS )
+PHP 8.1.5 (cli) (built: Apr 21 2022 10:32:13) (NTS)
 Copyright (c) The PHP Group
-Zend Engine v4.0.1, Copyright (c) Zend Technologies
-    with Zend OPcache v8.0.1, Copyright (c), by Zend Technologies
+Zend Engine v4.1.5, Copyright (c) Zend Technologies
+    with Zend OPcache v8.1.5, Copyright (c), by Zend Technologies
 
 vagrant@pterodactyl:~/app$ composer --version
-Composer version 2.0.8 2020-12-03 17:20:38
+Composer version 2.3.5 2022-04-13 16:43:00
 ```
 
 ## Self Upgrade

--- a/panel/1.0/webserver_configuration.md
+++ b/panel/1.0/webserver_configuration.md
@@ -63,7 +63,7 @@ a2dissite 000-default.conf
 ```
 
 Now, you should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
-`pterodactyl.conf` and place the file in `/etc/nginx/sites-available/`, or &mdash; if on CentOS, `/etc/nginx/conf.d/`.
+`pterodactyl.conf` and place the file in `/etc/apache2/sites-available`, or &mdash; if on CentOS, `/etc/httpd/conf.d/`.
 
 Note: When using Apache, make sure you have the `libapache2-mod-php` package installed or else PHP will not display on your webserver.
 
@@ -91,7 +91,7 @@ a2dissite 000-default.conf
 ```
 
 Now, you should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
-`pterodactyl.conf` and place the file in `/etc/nginx/sites-available/`, or &mdash; if on CentOS, `/etc/nginx/conf.d/`.
+`pterodactyl.conf` and place the file in `/etc/apache2/sites-available`, or &mdash; if on CentOS, `/etc/httpd/conf.d/`.
 
 Note: When using Apache, make sure you have the `libapache2-mod-php` package installed or else PHP will not display on your webserver.
 

--- a/panel/1.0/webserver_configuration.md
+++ b/panel/1.0/webserver_configuration.md
@@ -7,14 +7,16 @@ When using the SSL configuration you MUST create SSL certificates, otherwise you
 :::: tabs
 ::: tab "Nginx With SSL"
 First, remove the default NGINX configuration.
+
 ``` bash
 rm /etc/nginx/sites-enabled/default
 ```
 
-Now you should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
-`pterodactyl.conf` and place it in `/etc/nginx/sites-available/`, or &mdash; if on CentOS, `/etc/nginx/conf.d/`.
+Now, you should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
+`pterodactyl.conf` and place the file in `/etc/nginx/sites-available/`, or &mdash; if on CentOS, `/etc/nginx/conf.d/`.
 
-<<< @/.snippets/webservers/nginx-php8.0.conf{5,11,26-27}
+<<< @/.snippets/webservers/nginx-php8.1.conf{5,11,26-27}
+
 ### Enabling Configuration
 
 The final step is to enable your NGINX configuration and restart it.
@@ -30,14 +32,16 @@ sudo systemctl restart nginx
 :::
 ::: tab "Nginx Without SSL"
 First, remove the default NGINX configuration.
+
 ``` bash
 rm /etc/nginx/sites-enabled/default
 ```
 
-Now you should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
-`pterodactyl.conf` and place it in `/etc/nginx/sites-available/`, or &mdash; if on CentOS, `/etc/nginx/conf.d/`.
+Now, you should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
+`pterodactyl.conf` and place the file in `/etc/nginx/sites-available/`, or &mdash; if on CentOS, `/etc/nginx/conf.d/`.
 
-<<< @/.snippets/webservers/nginx-php8.0-nossl.conf{3}
+<<< @/.snippets/webservers/nginx-php8.1-nossl.conf{4}
+
 ### Enabling Configuration
 
 The final step is to enable your NGINX configuration and restart it.
@@ -53,16 +57,18 @@ sudo systemctl restart nginx
 :::
 ::: tab "Apache With SSL"
 First, remove the default Apache configuration.
+
 ``` bash
 a2dissite 000-default.conf
 ```
 
-Now you should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
-`pterodactyl.conf` and place it in `/etc/apache2/sites-available`, or &mdash; if on CentOS, `/etc/httpd/conf.d/`.
+Now, you should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
+`pterodactyl.conf` and place the file in `/etc/nginx/sites-available/`, or &mdash; if on CentOS, `/etc/nginx/conf.d/`.
 
 Note: When using Apache, make sure you have the `libapache2-mod-php` package installed or else PHP will not display on your webserver.
 
 <<< @/.snippets/webservers/apache.conf{2,10,24-25}
+
 ### Enabling Configuration
 
 Once you've created the file above, simply run the commands below. If you are on CentOS _you do not need to run the commands
@@ -79,17 +85,20 @@ sudo systemctl restart apache2
 :::
 ::: tab "Apache Without SSL"
 First, remove the default Apache configuration.
+
 ``` bash
 a2dissite 000-default.conf
 ```
 
-Now you should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
-`pterodactyl.conf` and place it in `/etc/apache2/sites-available`, or &mdash; if on CentOS, `/etc/httpd/conf.d/`.
+Now, you should paste the contents of the file below, replacing `<domain>` with your domain name being used in a file called
+`pterodactyl.conf` and place the file in `/etc/nginx/sites-available/`, or &mdash; if on CentOS, `/etc/nginx/conf.d/`.
 
 Note: When using Apache, make sure you have the `libapache2-mod-php` package installed or else PHP will not display on your webserver.
 
 <<< @/.snippets/webservers/apache-nossl.conf{2}
+
 ### Enabling Configuration
+
 Once you've created the file above, simply run the commands below. If you are on CentOS _you do not need to run the commands
 below!_ You only need to run `systemctl restart httpd`.
 

--- a/wings/1.0/upgrading.md
+++ b/wings/1.0/upgrading.md
@@ -16,7 +16,9 @@ most cases your base Wings version should match that of your Panel.
 | 1.3.x         | 1.3.x         |           |
 | 1.4.x         | 1.4.x         |           |
 | 1.5.x         | 1.4.x         |           |
-| **1.7.x**     | **1.5.x**     | ✅        |
+| 1.6.x         | 1.4.x         |           |
+| 1.7.x         | 1.5.x         |           |
+| **1.8.x**     | **1.6.x**     | ✅        |
 
 ## Download Updated Binary
 


### PR DESCRIPTION
## Only mergeable once PteroCycle 1.8+ is released

#### Added

Add Ubuntu 22.04 to the Guide

#### Changed
Use official Redis PPA, which supports all of the supported Ubuntu/Debian versions.
Use PHP 8.1, which for newer distro sources will be the default on apt upgrade and currently causes headaches for some users
Use Pterodactyl 1.8 for the Panel version.

Tested on Ubuntu LTS releases 18, 20, and 22.
