### PR TITLE
Add "composer update" warning

### DIFF
--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -132,6 +132,10 @@ composer install --no-dev --optimize-autoloader
 php artisan key:generate --force
 ```
 
+::: warning
+Do not run `composer update` or you will break your panel!
+:::
+
 ::: danger
 Back up your encryption key (APP_KEY in the `.env` file). It is used as an encryption key for all data that needs to be stored securely (e.g. api keys).
 Store it somewhere safe - not just on your server. If you lose it all encrypted data is irrecoverable -- even if you have database backups.


### PR DESCRIPTION
This is based on #443.

Dane said:
> Seeing as we never tell you to run it...

Actually when running `composer install` for the first time it suggests to update the dependencies. There is no harm in showing a little warning in the docs.