### PR TITLE
Suggested Redis official APT repository

### DIFF
--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -57,7 +57,10 @@ apt -y install software-properties-common curl apt-transport-https ca-certificat
 
 # Add additional repositories for PHP, Redis, and MariaDB
 LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php
-add-apt-repository ppa:redislabs/redis -y
+
+# Add Redis official APT repository
+curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
 
 # MariaDB repo setup script can be skipped on Ubuntu 22.04
 curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash


### PR DESCRIPTION
https://redis.io/docs/getting-started/installation/install-redis-on-linux/#install-on-ubuntu