### PR TITLE
use php8.1-common

### DIFF
--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -69,7 +69,7 @@ apt update
 apt-add-repository universe
 
 # Install Dependencies
-apt -y install php8.1 php8.1-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip} mariadb-server nginx tar unzip git redis-server
+apt -y install php8.1 php8.1-{common,cli,gd,mysql,mbstring,bcmath,xml,fpm,curl,zip} mariadb-server nginx tar unzip git redis-server
 ```
 
 ### Installing Composer


### PR DESCRIPTION
Note, selecting 'php8.1-common' instead of 'php8.1-pdo'
Note, selecting 'php8.1-common' instead of 'php8.1-tokenizer'

php8.1-common is a meta-package that installs most of the widely used PHP extensions in one-go. It automatically installs package such as php8.1-pdo, php8.1-tokenizer among other useful extensions.