### PR TITLE
Restart Wings in troubleshooting steps

### DIFF
--- a/tutorials/creating_ssl_certificates.md
+++ b/tutorials/creating_ssl_certificates.md
@@ -89,6 +89,11 @@ Once the process has complete, you can restart the Nginx service:
 ```bash
 systemctl start nginx
 ```
+You may also need to restart Wings as not every service is able to automatically apply an updated certificate:
+
+```bash
+systemctl restart wings
+```
 
 :::
 ::: tab "Method 2: acme.sh (Cloudflare)"


### PR DESCRIPTION
Add a line explaining the possible need to restart wings following a certificate renewal. This is already mentioned by the Support Bot in the Pterodactyl Discord server when linking this page, but is neglected on the page itself. Adding this line would help those who use this site as a primary resource. When I followed the steps on this page, I ran into instability with Wings as I didn't realize the certificate didn't apply automatically; having that explained here would have helped.