### PR TITLE
Update adding the docker user

### DIFF
--- a/community/config/eggs/creating_a_custom_image.md
+++ b/community/config/eggs/creating_a_custom_image.md
@@ -57,7 +57,7 @@ single [`RUN`](https://docs.docker.com/engine/reference/builder/#run) block.
 Within this `RUN` block, you'll notice the `useradd` command.
 
 ```bash
-adduser -D -h /home/container container
+useradd -ms /home/container container
 ```
 
 ::: warning


### PR DESCRIPTION
Based on https://stackoverflow.com/questions/27701930/how-to-add-users-to-docker-container 
Original ```adduser -D -h /home/container container``` returns error ```Option d is ambiguous (debug, disabled-login, disabled-password)```.