### PR TITLE
Document new environment variables for S3 backup

### DIFF
--- a/panel/1.0/additional_configuration.md
+++ b/panel/1.0/additional_configuration.md
@@ -41,6 +41,14 @@ AWS_ENDPOINT=
 ```
 For some configurations, you might have to change your S3 URL from `bucket.domain.com` to `domain.com/bucket`. To accomplish this, add `AWS_USE_PATH_STYLE_ENDPOINT=true` to your `.env` file.
 
+The S3 backup is using the S3 multipart upload capabilities. In rare situations, you might want to adjust the size of a single part or the lifespan of the generated pre-signed URLs. The default part size is 5GB and the default pre-signed URL lifespan is 60 minutes. You can configure the maximal part size using the `BACKUP_MAX_PART_SIZE` environment variable. You must specify the size in bytes. To define the pre-signed URL lifespan, use the `BACKUP_PRESIGNED_URL_LIFESPAN` variable. The expected unit is minutes.
+
+The following `.env` snippet configures 1GB parts and uses 120 minutes as the pre-signed URL lifespan:
+```bash
+BACKUP_MAX_PART_SIZE=1073741824
+BACKUP_PRESIGNED_URL_LIFESPAN=120
+```
+
 ## Reverse Proxy Setup
 
 When running Pterodactyl behind a reverse proxy, such as [Cloudflare's Flexible SSL](https://support.cloudflare.com/hc/en-us/articles/200170416-What-do-the-SSL-options-mean-)

--- a/panel/1.0/additional_configuration.md
+++ b/panel/1.0/additional_configuration.md
@@ -39,11 +39,13 @@ AWS_SECRET_ACCESS_KEY=
 AWS_BACKUPS_BUCKET=
 AWS_ENDPOINT=
 ```
+
 For some configurations, you might have to change your S3 URL from `bucket.domain.com` to `domain.com/bucket`. To accomplish this, add `AWS_USE_PATH_STYLE_ENDPOINT=true` to your `.env` file.
 
-The S3 backup is using the S3 multipart upload capabilities. In rare situations, you might want to adjust the size of a single part or the lifespan of the generated pre-signed URLs. The default part size is 5GB and the default pre-signed URL lifespan is 60 minutes. You can configure the maximal part size using the `BACKUP_MAX_PART_SIZE` environment variable. You must specify the size in bytes. To define the pre-signed URL lifespan, use the `BACKUP_PRESIGNED_URL_LIFESPAN` variable. The expected unit is minutes.
+The S3 backup is using the S3 multipart upload capabilities. In rare situations, you might want to adjust the size of a single part or the lifespan of the generated pre-signed URLs. The default part size is 5GB, and the default pre-signed URL lifespan is 60 minutes. You can configure the maximal part size using the `BACKUP_MAX_PART_SIZE` environment variable. You must specify the size in bytes. To define the pre-signed URL lifespan, use the `BACKUP_PRESIGNED_URL_LIFESPAN` variable. The expected unit is minutes.
 
 The following `.env` snippet configures 1GB parts and uses 120 minutes as the pre-signed URL lifespan:
+
 ```bash
 BACKUP_MAX_PART_SIZE=1073741824
 BACKUP_PRESIGNED_URL_LIFESPAN=120
@@ -75,6 +77,7 @@ proxy_request_buffering off;
 ```
 
 ### Cloudflare Specific Configuration
+
 If you're using Cloudflare's Flexible SSL you should set `TRUSTED_PROXIES` to contain [their IP addresses](https://www.cloudflare.com/ips/).
 Below is an example of how to set this.
 
@@ -107,7 +110,6 @@ reCAPTCHA can easily be disabled using the admin panel. In the Settings, select 
 #### Editing your database
 
 If you cannot access your panel, you can modify the database directly using the following commands.
-
 
 ```sql
 mysql -u root -p


### PR DESCRIPTION
There has been a new `BACKUP_MAX_PART_SIZE` environment variable added. Also, there is a variable for the pre-signed URL lifespan that has never been documented.

This PR adds documentation about these two environment variables.

This is in companion with:
 - PR: [pterodactyl/panel#4382](https://github.com/pterodactyl/panel/pull/4382)
 - Issue: [pterodactyl/panel#4361](https://github.com/pterodactyl/panel/issues/4361)

**Note:** `BACKUP_MAX_PART_SIZE` is not released yet. Maybe leave this PR until the next pane lrelease.