### PR TITLE
feat(customization): include openssl-legacy-provider notice

### DIFF
--- a/community/customization/panel.md
+++ b/community/customization/panel.md
@@ -37,10 +37,11 @@ yarn # Installs panel build dependencies
 
 ## Build Panel Assets
 
-The following command will rebuild the Panel frontend.
+The following command will rebuild the Panel frontend. For NodeJS version 15 and above, you must enable the `--openssl-legacy-provider` option before building.
 
 ```bash
 cd /var/www/pterodactyl
+export NODE_OPTIONS=--openssl-legacy-provider # for NodeJS v15+
 yarn build:production # Build panel
 ```
 

--- a/community/customization/panel.md
+++ b/community/customization/panel.md
@@ -37,11 +37,11 @@ yarn # Installs panel build dependencies
 
 ## Build Panel Assets
 
-The following command will rebuild the Panel frontend. For NodeJS version 15 and above, you must enable the `--openssl-legacy-provider` option before building.
+The following command will rebuild the Panel frontend. For NodeJS version 17 and above, you must enable the `--openssl-legacy-provider` option before building.
 
 ```bash
 cd /var/www/pterodactyl
-export NODE_OPTIONS=--openssl-legacy-provider # for NodeJS v15+
+export NODE_OPTIONS=--openssl-legacy-provider # for NodeJS v17+
 yarn build:production # Build panel
 ```
 


### PR DESCRIPTION
Adds notice for building with NodeJS v15+, closes #484.