### PR TITLE
Add environment variables page

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -148,6 +148,7 @@ module.exports = {
                                 '/getting_started',
                                 '/webserver_configuration',
                                 '/additional_configuration',
+                                '/environment_variables',
                                 '/updating',
                                 '/troubleshooting',
                                 '/legacy_upgrade',

--- a/panel/1.0/environment_variables.md
+++ b/panel/1.0/environment_variables.md
@@ -1,0 +1,35 @@
+# Environment Variables
+
+[[toc]]
+
+## Application Variables
+
+| Name | Default Value | Allowed Values | Description |
+|------|---------------|----------------|-------------|
+| `APP_NAME` | "Pterodactyl" | Any | The name of your panel, this is shown in the header of pages in the panel. |
+| `APP_ENV` | "production" | Any | The environment your panel is currently running in. |
+| `APP_DEBUG` | false | true, false | When in debug mode, more detailed information including stack traces will be logged from the panel. |
+| `APP_URL` | "http://localhost" | Any | The URL your panel is running on, this is used for generating URLs for other services. |
+| `APP_TIMEZONE` | "UTC" | [Supported Timezones](https://www.php.net/manual/en/timezones.php) | The timezone for the panel, used for date-time functions and services. |
+| `APP_LOCALE` | "en" | Any | The locale for the panel used for translations. Note that the panel **does not** have a translations system yet, so it is recommended to keep the value as "en". |
+| `APP_KEY` | | Any | The encryption key for the panel, see [Getting Started](/panel/1.0/getting_started.md#installation). |
+| `APP_REPORT_ALL_EXCEPTIONS` | false | true, false | Logs all exceptions reported by the panel. |
+
+## Backups Variables
+
+| Name | Default Value | Allowed Values | Description |
+|------|---------------|----------------|-------------|
+| `APP_BACKUP_DRIVER` | "wings" | "wings", "s3" | The driver to use for managing server backups. |
+| `BACKUP_PRESIGNED_URL_LIFESPAN` | 60 | Any Number | The time in minutes for the lifespan of presigned URLs used for uploading backups to S3 storage. |
+| `BACKUP_MAX_PART_SIZE` | 5368709120 | Any Number | The maximum size in bytes of a single upload part for S3 storage. |
+| `BACKUP_PRUNE_AGE` | 360 | Any Number | The time in minutes to wait before automatically failing an incomplete backup. Set to `0` to disable. |
+| `BACKUP_THROTTLE_LIMIT` | 2 | Any Number | The number of backups that can be created within the backup throttle period, this includes deleted backups. Set to `0` to disable. |
+| `BACKUP_THROTTLE_PERIOD` | 600 | Any Number | The time period in seconds to allow backups to be created in. |
+| `AWS_DEFAULT_REGION` | | Any | The region of the S3 storage. |
+| `AWS_ACCESS_KEY_ID` | | Any | |
+| `AWS_SECRET_ACCESS_KEY` | | Any | |
+| `AWS_BACKUPS_BUCKET` | | Any | |
+| `AWS_ENDPOINT` | | Any | |
+| `AWS_USE_PATH_STYLE_ENDPOINT` | false | true, false | |
+| `AWS_BACKUPS_USE_ACCELERATE` | false | true, false | |
+| `AWS_BACKUPS_STORAGE_CLASS` | | Any | |


### PR DESCRIPTION
Adds initial concept for an environment variables page under the Panel section. This is following the configurations set [in the panel files](https://github.com/pterodactyl/panel/tree/develop/config). Variables reused in other config files will not be defined in multiple sections, but they may be referenced in the descriptions. Closes #471.

## Variables
Sections with "requires discussion" are yet to be added or completed as they require further discussion on how it should be documented or amendments with the current documentation.

* [x] Application (`config/app.php`)
* [ ] Backups (`config/backups.php`)
* [ ] Broadcasts (`config/broadcasting.php`)
* [ ] Caching (`config/cache.php`) (requires discussion)
* [ ] CORS (`config/cors.php`)
* [ ] Database (`config/database.php`)
* [ ] Filesystems (`config/filesystems.php`) (requires discussion)
* [ ] Hashids (`config/hashids.php`)
* [ ] Hashing (`config/hashing.php`)
* [ ] HTTP (`config/http.php`)
* [ ] Logging (`config/logging.php`)
* [ ] Mail (`config/mail.php`)
* [ ] Pterodactyl (`config/pterodactyl.php`) (requires discussion)
* [ ] Queue (`config/queue.php`)
* [ ] reCAPTCHA (`config/recaptcha.php`)
* [ ] Sanctum (`config/sanctum.php`) (requires discussion)
* [ ] Services (`config/services.php`)
* [ ] Session (`config/session.php`)
* [ ] Trusted Proxy (`config/trustedproxy.php`)
* [ ] Views (`config/view.php`) (requires discussion)

Please **do not** make requests about the formatting of the tables until after this PR is ready to merge as the information is subject to change which requires constant reformatting.