### PR TITLE
Proxying Wings FQDN through Cloudflare

### DIFF
--- a/wings/1.0/configuration.md
+++ b/wings/1.0/configuration.md
@@ -55,7 +55,7 @@ After making changes, the following commands will stop the Wings, remove the Pte
 
 Cloudflare proxying of the Wings isn't beneficial since users will be connecting to the machine directly and bypassing any Cloudflare protection. As such, your Node machine IP will still be exposed.
 
-To enable Cloudflare proxy, you must change the Wings port to one of the Cloudflare HTTPS ports, such as 8443, because Cloudflare only supports HTTP on port 8080. Select your Node in the Admin Panel, and on the settings tab, change the port.
+To enable Cloudflare proxy, you must change the Wings port to one of the Cloudflare HTTPS ports with caching enabled (more info [here](https://developers.cloudflare.com/fundamentals/get-started/reference/network-ports/)), such as 8443, because Cloudflare only supports HTTP on port 8080. Select your Node in the Admin Panel, and on the settings tab, change the port, then on Cloudflare dashboard, your FQDN must have an orange cloud enabled beside it.
 
 You are unable to proxy the SFTP port through Cloudflare unless you have their enterprise plan.
 


### PR DESCRIPTION
Added some more info for proxying Wings FQDN through Cloudflare. This has been tested a few minutes ago and came to a conclusion that the FQDN must have the port that Cloudflare has (so HTTPS ports with caching enabled).
Tell me if anything is wrong here, I'm glad to help figure it out!