### PR TITLE
Stricter security headers

### DIFF
--- a/.snippets/webservers/nginx-centos.conf
+++ b/.snippets/webservers/nginx-centos.conf
@@ -19,7 +19,7 @@ server {
     # allow larger file uploads and longer script runtimes
     client_max_body_size 100m;
     client_body_timeout 120s;
-    
+
     sendfile off;
 
     # SSL Configuration
@@ -32,12 +32,16 @@ server {
 
     # See https://hstspreload.org/ before uncommenting the line below.
     # add_header Strict-Transport-Security "max-age=15768000; preload;";
-    add_header X-Content-Type-Options nosniff;
-    add_header X-XSS-Protection "1; mode=block";
-    add_header X-Robots-Tag none;
-    add_header Content-Security-Policy "frame-ancestors 'self'";
-    add_header X-Frame-Options DENY;
-    add_header Referrer-Policy same-origin;
+    add_header Content-Security-Policy "default-src 'none'; connect-src *; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' https://www.gravatar.com; frame-src https://recaptcha.net; manifest-src 'self'; script-src 'self' 'unsafe-inline' https://recaptcha.net https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; frame-ancestors 'self'; block-all-mixed-content; base-uri 'none'";
+    add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), magnetometer=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), sync-xhr=(), xr-spatial-tracking=()";
+    add_header Referrer-Policy "same-origin" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    #add_header X-UA-Compatible "IE=Edge" always;
+    add_header X-XSS-Protection "0" always;
+    add_header Cross-Origin-Resource-Policy same-origin;
+    add_header Cross-Origin-Opener-Policy same-origin;
+    add_header X-XSS-Protection "0" always;
+    # add_header Expect-CT "enforce, max-age=63072000";
 
     location / {
         try_files $uri $uri/ /index.php?$query_string;

--- a/.snippets/webservers/nginx-php7.4.conf
+++ b/.snippets/webservers/nginx-php7.4.conf
@@ -32,12 +32,16 @@ server {
 
     # See https://hstspreload.org/ before uncommenting the line below.
     # add_header Strict-Transport-Security "max-age=15768000; preload;";
-    add_header X-Content-Type-Options nosniff;
-    add_header X-XSS-Protection "1; mode=block";
-    add_header X-Robots-Tag none;
-    add_header Content-Security-Policy "frame-ancestors 'self'";
-    add_header X-Frame-Options DENY;
-    add_header Referrer-Policy same-origin;
+    add_header Content-Security-Policy "default-src 'none'; connect-src *; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' https://www.gravatar.com; frame-src https://recaptcha.net; manifest-src 'self'; script-src 'self' 'unsafe-inline' https://recaptcha.net https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; frame-ancestors 'self'; block-all-mixed-content; base-uri 'none'";
+    add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), magnetometer=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), sync-xhr=(), xr-spatial-tracking=()";
+    add_header Referrer-Policy "same-origin" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    #add_header X-UA-Compatible "IE=Edge" always;
+    add_header X-XSS-Protection "0" always;
+    add_header Cross-Origin-Resource-Policy same-origin;
+    add_header Cross-Origin-Opener-Policy same-origin;
+    add_header X-XSS-Protection "0" always;
+    # add_header Expect-CT "enforce, max-age=63072000";
 
     location / {
         try_files $uri $uri/ /index.php?$query_string;

--- a/.snippets/webservers/nginx-php7.4.conf
+++ b/.snippets/webservers/nginx-php7.4.conf
@@ -41,7 +41,6 @@ server {
     add_header Cross-Origin-Resource-Policy same-origin;
     add_header Cross-Origin-Opener-Policy same-origin;
     add_header X-XSS-Protection "0" always;
-    # add_header Expect-CT "enforce, max-age=63072000";
 
     location / {
         try_files $uri $uri/ /index.php?$query_string;

--- a/.snippets/webservers/nginx-php8.0.conf
+++ b/.snippets/webservers/nginx-php8.0.conf
@@ -32,12 +32,16 @@ server {
 
     # See https://hstspreload.org/ before uncommenting the line below.
     # add_header Strict-Transport-Security "max-age=15768000; preload;";
-    add_header X-Content-Type-Options nosniff;
-    add_header X-XSS-Protection "1; mode=block";
-    add_header X-Robots-Tag none;
-    add_header Content-Security-Policy "frame-ancestors 'self'";
-    add_header X-Frame-Options DENY;
-    add_header Referrer-Policy same-origin;
+    add_header Content-Security-Policy "default-src 'none'; connect-src *; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' https://www.gravatar.com; frame-src https://recaptcha.net; manifest-src 'self'; script-src 'self' 'unsafe-inline' https://recaptcha.net https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; frame-ancestors 'self'; block-all-mixed-content; base-uri 'none'";
+    add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), magnetometer=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), sync-xhr=(), xr-spatial-tracking=()";
+    add_header Referrer-Policy "same-origin" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    #add_header X-UA-Compatible "IE=Edge" always;
+    add_header X-XSS-Protection "0" always;
+    add_header Cross-Origin-Resource-Policy same-origin;
+    add_header Cross-Origin-Opener-Policy same-origin;
+    add_header X-XSS-Protection "0" always;
+    # add_header Expect-CT "enforce, max-age=63072000";
 
     location / {
         try_files $uri $uri/ /index.php?$query_string;

--- a/.snippets/webservers/nginx-php8.0.conf
+++ b/.snippets/webservers/nginx-php8.0.conf
@@ -41,7 +41,6 @@ server {
     add_header Cross-Origin-Resource-Policy same-origin;
     add_header Cross-Origin-Opener-Policy same-origin;
     add_header X-XSS-Protection "0" always;
-    # add_header Expect-CT "enforce, max-age=63072000";
 
     location / {
         try_files $uri $uri/ /index.php?$query_string;

--- a/.snippets/webservers/nginx-php8.1.conf
+++ b/.snippets/webservers/nginx-php8.1.conf
@@ -32,12 +32,16 @@ server {
 
     # See https://hstspreload.org/ before uncommenting the line below.
     # add_header Strict-Transport-Security "max-age=15768000; preload;";
-    add_header X-Content-Type-Options nosniff;
-    add_header X-XSS-Protection "1; mode=block";
-    add_header X-Robots-Tag none;
-    add_header Content-Security-Policy "frame-ancestors 'self'";
-    add_header X-Frame-Options DENY;
-    add_header Referrer-Policy same-origin;
+    add_header Content-Security-Policy "default-src 'none'; connect-src *; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' https://www.gravatar.com; frame-src https://recaptcha.net; manifest-src 'self'; script-src 'self' 'unsafe-inline' https://recaptcha.net https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; frame-ancestors 'self'; block-all-mixed-content; base-uri 'none'";
+    add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), magnetometer=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), sync-xhr=(), xr-spatial-tracking=()";
+    add_header Referrer-Policy "same-origin" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    #add_header X-UA-Compatible "IE=Edge" always;
+    add_header X-XSS-Protection "0" always;
+    add_header Cross-Origin-Resource-Policy same-origin;
+    add_header Cross-Origin-Opener-Policy same-origin;
+    add_header X-XSS-Protection "0" always;
+    # add_header Expect-CT "enforce, max-age=63072000";
 
     location / {
         try_files $uri $uri/ /index.php?$query_string;

--- a/.snippets/webservers/nginx-php8.1.conf
+++ b/.snippets/webservers/nginx-php8.1.conf
@@ -41,7 +41,6 @@ server {
     add_header Cross-Origin-Resource-Policy same-origin;
     add_header Cross-Origin-Opener-Policy same-origin;
     add_header X-XSS-Protection "0" always;
-    # add_header Expect-CT "enforce, max-age=63072000";
 
     location / {
         try_files $uri $uri/ /index.php?$query_string;


### PR DESCRIPTION
I updated the security headers for NGINX with SSL to be much stricter. I added CSP policies, permission policies, CORP and COOP. I do not see the docs setting them for non SSL NGINX and Apache, so I did not add them there.

`X-XSS-Protection "1; mode=block";` is changed to `X-XSS-Protection "0" always;` as we already have a CSP policies, and it is generally recommended that it be disabled as it can cause more harm than good. 

