### PR TITLE
docs(legacy): Update required PHP version

### DIFF
--- a/panel/1.0/legacy_upgrade.md
+++ b/panel/1.0/legacy_upgrade.md
@@ -16,7 +16,7 @@ php artisan down
 You'll need to make sure your system dependencies are up to date before performing this upgrade. Please
 reference the list below to ensure you have all of the required versions.
 
-* PHP `7.4`, `8.0` or `8.1` (recommended) with the following extensions: `cli`, `openssl`, `gd`, `mysql`, `PDO`, `mbstring`,
+* PHP `8.0` or `8.1` (recommended) with the following extensions: `cli`, `openssl`, `gd`, `mysql`, `PDO`, `mbstring`,
   `tokenizer`, `bcmath`, `xml` or `dom`, `curl`, `zip`, and `fpm` if you are planning to use nginx. See our guide
   for [Upgrading PHP](/guides/php_upgrade.md) for details.
 * Composer v2 (`composer self-update --2`)


### PR DESCRIPTION
As of panel version 1.11.1, the required PHP version jumped to PHP 8.0.