### PR TITLE
chore: update supported versions

### DIFF
--- a/panel/1.0/updating.md
+++ b/panel/1.0/updating.md
@@ -9,26 +9,27 @@ Each version of Pterodactyl Panel also has a corresponding minimum version of Wi
 is required for it to run. Please see the chart below for how these versions line up. In
 most cases your base Wings version should match that of your Panel.
 
-| Panel Version | Wings Version | Supported | PHP Versions                       |
-|---------------|---------------|-----------|------------------------------------|
-| 1.0.x         | 1.0.x         |           | 7.3, 7.4                           |
-| 1.1.x         | 1.1.x         |           | 7.3, 7.4                           |
-| 1.2.x         | 1.2.x         |           | 7.3, 7.4                           |
-| 1.3.x         | 1.3.x         |           | 7.4, 8.0                           |
-| 1.4.x         | 1.4.x         |           | 7.4, 8.0                           |
-| 1.5.x         | 1.4.x         |           | 7.4, 8.0                           |
-| 1.6.x         | 1.4.x         |           | 7.4, 8.0                           |
-| 1.7.x         | 1.5.x         |           | 7.4, 8.0                           |
-| 1.8.x         | 1.6.x         |           | 7.4, 8.0, 8.1                      |
-| 1.9.x         | 1.6.x         |           | 7.4, 8.0, 8.1                      |
-| **1.10.x**    | **1.7.x**     | ✅         | 7.4, 8.0, **8.1** (7.4 deprecated) |
-| **1.11.x**    | **1.11.x**    | ✅         | 8.0, **8.1** (8.0 deprecated)      |
+| Panel Version | Wings Version | Supported | PHP Versions                  |
+| ------------- | ------------- | --------- | ----------------------------- |
+| 1.0.x         | 1.0.x         |           | 7.3, 7.4                      |
+| 1.1.x         | 1.1.x         |           | 7.3, 7.4                      |
+| 1.2.x         | 1.2.x         |           | 7.3, 7.4                      |
+| 1.3.x         | 1.3.x         |           | 7.4, 8.0                      |
+| 1.4.x         | 1.4.x         |           | 7.4, 8.0                      |
+| 1.5.x         | 1.4.x         |           | 7.4, 8.0                      |
+| 1.6.x         | 1.4.x         |           | 7.4, 8.0                      |
+| 1.7.x         | 1.5.x         |           | 7.4, 8.0                      |
+| 1.8.x         | 1.6.x         |           | 7.4, 8.0, 8.1                 |
+| 1.9.x         | 1.6.x         |           | 7.4, 8.0, 8.1                 |
+| 1.10.x        | 1.7.x         |           | 7.4, 8.0, 8.1                 |
+| **1.11.x**    | **1.11.x**    | ✅        | 8.0, **8.1** (8.0 deprecated) |
 
-*NOTE: There are no 1.8.x, 1.9.x, or 1.10.x releases of Wings.*
+_NOTE: There are no 1.8.x, 1.9.x, or 1.10.x releases of Wings._
 
 ## Update Dependencies
-* PHP `8.0` or `8.1` (recommended)
-* Composer `2.X`
+
+- PHP `8.0` or `8.1` (recommended)
+- Composer `2.X`
 
 ::: danger PHP 7.4
 Support for PHP 7.4 has been removed with the release of 1.11.0. Please upgrade
@@ -37,7 +38,7 @@ to PHP 8.0, 8.1 or newer.
 
 ::: warning Future PHP Version Changes
 **Support for PHP 8.0 is deprecated**. Please plan accordingly — PHP 8.1 or newer
- will be the only supported version in 1.12 and beyond.
+will be the only supported version in 1.12 and beyond.
 :::
 
 **Before continuing**, please ensure that your system and web server configuration has been upgraded to at least PHP 8.0 by running `php -v` and Composer 2 by running `composer --version`. You


### PR DESCRIPTION
Updates the supported versions section to reflect v1.10.x of the panel (and subsequently the corresponding Wings version) as unsupported.