### PR TITLE
Remove colons from Permissions

### DIFF
--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -182,10 +182,10 @@ The last step in the installation process is to set the correct permissions on t
 use them correctly.
 
 ``` bash
-# If using NGINX or Apache (not on CentOS):
+# If using NGINX or Apache (not on CentOS)
 chown -R www-data:www-data /var/www/pterodactyl/*
 
-# If using NGINX on CentOS:
+# If using NGINX on CentOS
 chown -R nginx:nginx /var/www/pterodactyl/*
 
 # If using Apache on CentOS


### PR DESCRIPTION
1. There's no colon for Apache on CentOS
2. Is there really a reason for them?