### PR TITLE
Set nodejs version to 16

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -17,6 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+    
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 


### PR DESCRIPTION
The current builds are failing because of the ssl crypto issue, this should fix it.

EDIT: it nows build the assets just fine