### PR TITLE
Do not recommend to use the panel db user for a database host

### DIFF
--- a/tutorials/mysql_setup.md
+++ b/tutorials/mysql_setup.md
@@ -39,12 +39,10 @@ CREATE DATABASE panel;
 
 ### Assigning permissions
 Finally, we need to tell MySQL that our pterodactyl user should have access to the panel database. To do this, simply
-run the command below. If you plan on also using this MySQL instance as a database host on the Panel you'll want to
-include the `WITH GRANT OPTION` (which we are doing here). If you won't be using this user as part of the host setup
-you can remove that.
+run the command below.
 
 ``` sql
-GRANT ALL PRIVILEGES ON panel.* TO 'pterodactyl'@'127.0.0.1' WITH GRANT OPTION;
+GRANT ALL PRIVILEGES ON panel.* TO 'pterodactyl'@'127.0.0.1';
 ```
 
 ## Creating a Database Host for Nodes


### PR DESCRIPTION
It's better to create a separate user for the database host. The panel db user won't work as database host user anyways since it has only access to the `panel` db.

Also, most people just blindly copy and paste the commands from the docs so they would create the panel db user with `GRANT` permissions. This is not needed.