### PR TITLE
Add posix requirement for composer

### DIFF
--- a/community/installation-guides/panel/centos8.md
+++ b/community/installation-guides/panel/centos8.md
@@ -46,7 +46,7 @@ dnf install -y php php-{common,fpm,cli,json,mysqlnd,gd,mbstring,pdo,zip,bcmath,d
 
 ### Composer
 ```bash
-dnf install -y zip unzip tar # Required for Composer
+dnf install -y zip unzip tar php-posix # Required for Composer
 curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ```
 


### PR DESCRIPTION
Not sure why they added this, but I guess it is what it is as composer will not run without this php extension.