### PR TITLE
Use packages for installing NodeJS instead of the installer as not supported

### DIFF
--- a/community/customization/panel.md
+++ b/community/customization/panel.md
@@ -4,7 +4,7 @@
 Do **not** run the following steps on your production nodes.
 :::
 
-Instructions on how to build the panel are also available in the [BUILDING.md](https://github.com/pterodactyl/panel/blob/v1.11.3/BUILDING.md) file.
+Instructions on how to build the panel are also available in the [BUILDING.md](https://github.com/pterodactyl/panel/blob/1.0-develop/BUILDING.md) file.
 
 The frontend of the Panel is built with React. Any changes to the source files require to recompile it.
 This also applies to style sheets. The following sections explain how to do so.

--- a/community/customization/panel.md
+++ b/community/customization/panel.md
@@ -17,13 +17,16 @@ The build tools require NodeJS, yarn is used as the package manager.
 
 ```bash
 # Ubuntu/Debian
-curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+
+apt update
 apt install -y nodejs
 
 # CentOS
-curl -sL https://rpm.nodesource.com/setup_16.x | sudo -E bash -
-sudo yum install -y nodejs yarn # CentOS 7
-sudo dnf install -y nodejs yarn # CentOS 8
+sudo yum install https://rpm.nodesource.com/pub_16.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y
+sudo yum install nodejs -y
 ```
 
 Install required javascript packages.

--- a/community/customization/panel.md
+++ b/community/customization/panel.md
@@ -4,7 +4,7 @@
 Do **not** run the following steps on your production nodes.
 :::
 
-Instructions on how to build the panel are also available in the [BUILDING.md](https://github.com/pterodactyl/panel/blob/develop/BUILDING.md) file.
+Instructions on how to build the panel are also available in the [BUILDING.md](https://github.com/pterodactyl/panel/blob/v1.11.3/BUILDING.md) file.
 
 The frontend of the Panel is built with React. Any changes to the source files require to recompile it.
 This also applies to style sheets. The following sections explain how to do so.

--- a/community/customization/panel.md
+++ b/community/customization/panel.md
@@ -21,8 +21,8 @@ sudo mkdir -p /etc/apt/keyrings
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 
-apt update
-apt install -y nodejs
+sudo apt update
+sudo apt install -y nodejs
 
 # CentOS
 sudo yum install https://rpm.nodesource.com/pub_16.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y


### PR DESCRIPTION
As stated on [nodesource/distributions#readme](https://github.com/nodesource/distributions#readme):
## **New Update ⚠️**

We'd like to inform you of important changes to our distribution repository [nodesource/distributions](https://github.com/nodesource/distributions).

**What's New:**

- _**Installation Scripts:** The installation scripts `setup_XX.x` are no longer supported and are not needed anymore, as the installation process is straightforward for any RPM and DEB distro._

---

Closes #543