### PR TITLE
Update creating_ssl_certificates.md

### DIFF
--- a/tutorials/creating_ssl_certificates.md
+++ b/tutorials/creating_ssl_certificates.md
@@ -112,7 +112,7 @@ After installing acme.sh, we need to fetch a CloudFlare API key. On Cloudfare's 
 Since the configuration file is based on Certbot, we need to create the folder manually.
 
 ```bash
-sudo mkdir /etc/letsencrypt/live/example.com
+sudo mkdir -p /etc/letsencrypt/live/example.com
 ```
 
 After installing acme.sh and obtaining CloudFlare API key, we need to then generate a certificate. First input the CloudFlare API credentials.


### PR DESCRIPTION
Updated acme.sh page to include the '-p' option when creating the directory to run the acme.sh file. Without this flag linux complains about the directory not existing.