### PR TITLE
Add sudo to systemctl enable --now wings

### DIFF
--- a/wings/1.0/installing.md
+++ b/wings/1.0/installing.md
@@ -170,7 +170,7 @@ WantedBy=multi-user.target
 Then, run the commands below to reload systemd and start Wings.
 
 ```bash
-systemctl enable --now wings
+sudo systemctl enable --now wings
 ```
 
 ### Node Allocations


### PR DESCRIPTION
Every systemctl command in the documentation has sudo before, why not this one ?