### PR TITLE
Rewrite Creating Custom egg and Docker image

### DIFF
--- a/community/config/eggs/creating_a_custom_egg.md
+++ b/community/config/eggs/creating_a_custom_egg.md
@@ -104,7 +104,7 @@ Avoid using this parser if possible.
 * `xml`
 
 ::: tip
-If you want to use egg non stock variables in the configuration parser you mist reference them as `{{server.build.env.ENVNAME}}` or just `{{env.ENVNAME}}`. Do not forget to to replace `ENVNAME` with the actual enviroment name you have setup.
+If you want to use egg non stock variables in the configuration parser you must reference them as `{{server.build.env.ENVNAME}}` or just `{{env.ENVNAME}}`. Do not forget to to replace `ENVNAME` with the actual enviroment name you have setup.
 :::
 
 Once you have defined a parser, we then define a `find` block which tells the Daemon what specific elements to find

--- a/community/config/eggs/creating_a_custom_egg.md
+++ b/community/config/eggs/creating_a_custom_egg.md
@@ -41,7 +41,7 @@ Please be aware of how the pterodactyl install proces works!
     Creates a new container using an install image which runs as root.
     Uses a volume mount on `/mnt/server` for the server files, which is the working directory during installation.
     The volume will be later mounted as `/home/container` for the server container. Any files outside of `/mnt/server` will be gone after installation.
-    The installation script can set up everything that's required to run the server, such as writing files, creating directories, or compiling apps."
+    The installation script can set up everything that's required to run the server, such as writing files, creating directories, or compiling apps.
     It is regularly used to just download the files required, such as server files and configs.
     
 2. Stop and destroy install container

--- a/community/config/eggs/creating_a_custom_egg.md
+++ b/community/config/eggs/creating_a_custom_egg.md
@@ -38,16 +38,16 @@ Please be aware of how the pterodactyl install proces works!
 
 ```
 1. Spin up install container
-    Creates a new container using an install image that's run as root.
+    Creates a new container using an install image which runs as root.
     Uses a volume mount on `/mnt/server` for the server files, which is the working directory during installation.
     The volume will be later mounted as `/home/container` for the server container. Any files outside of `/mnt/server` will be gone after installation.
-    Install script can pull files or set up all that is needed to run the server, such as writing files, directories or compiling apps.
-    It is regularly used to just download the files required. Such as server files and configs.
+    The installation script can set up everything that's required to run the server, such as writing files, creating directories, or compiling apps."
+    It is regularly used to just download the files required, such as server files and configs.
     
 2. Stop and destroy install container
 
 3. Start a new container with the server files in /home/container
-    This is where the server is actually run. No root privileges.
+    This is where the server is is actually ran, without root privileges.
     Any dependencies installed during the install process are gone.
     The container that is started should have everything you need.
     No packages can be installed. Any required dependencies must exist in the used Docker image.
@@ -161,7 +161,7 @@ The file parser  the whole line that you are trying to edit. For example:
 }
 ```
 
-The `"` on the right side are escaped with a `\` because else they would brake the json syntax for the parser.
+The `"` on the right side are escaped with a `\` because else they would break the json syntax for the parser.
 
 ### Start Configuration
 The last block to configure is the `Start Configuration` for servers running using this service option.

--- a/community/config/eggs/creating_a_custom_egg.md
+++ b/community/config/eggs/creating_a_custom_egg.md
@@ -33,7 +33,7 @@ our [Creating a Docker Image](/community/config/eggs/creating_a_custom_image.md)
 ## The Pterodactyl Install Procces
 
 ::: warning
-Please be aware of how the pterodactyl install proces works!
+Please be aware of how the pterodactyl install process works!
 :::
 
 ```
@@ -104,7 +104,7 @@ Avoid using this parser if possible.
 * `xml`
 
 ::: tip
-If you want to use egg non stock variables in the configuration parser you must reference them as `{{server.build.env.ENVNAME}}` or just `{{env.ENVNAME}}`. Do not forget to to replace `ENVNAME` with the actual enviroment name you have setup.
+If you want to use egg non stock variables in the configuration parser you must reference them as `{{server.build.env.ENVNAME}}` or just `{{env.ENVNAME}}`. Do not forget to to replace `ENVNAME` with the actual environment name you have setup.
 :::
 
 Once you have defined a parser, we then define a `find` block which tells the Daemon what specific elements to find
@@ -144,7 +144,7 @@ docker interface defined in the configuration file using `{{config.docker.interf
 :::
 
 #### File Parser
-The file parser  the whole line that you are trying to edit. For example:
+The file parser replaces the whole line that you are trying to edit. So you have to use it like this:
 
 ```json
 {
@@ -176,7 +176,7 @@ In the example block above, we define `done` as the entire line, or part of a li
 starting, and is ready for players to join. When the Daemon sees this output, it will mark the server as `ON` rather
 than `STARTING`. 
 
-If your aplication has multiple messages that mean that it is fully startup then you can also do it like this:
+If your application has multiple messages that mean that it is fully startup then you can also do it like this:
 ```json
 {
   "done":[

--- a/community/config/eggs/creating_a_custom_egg.md
+++ b/community/config/eggs/creating_a_custom_egg.md
@@ -72,7 +72,7 @@ This can be set like below.
 
 ```json
 {}
-``` 
+```
 
 ### Configuration Files
 The next block is one of the most complex blocks, the `Configuration Files` descriptor. The Daemon will process this
@@ -104,7 +104,15 @@ Avoid using this parser if possible.
 * `xml`
 
 ::: tip
-If you want to use egg non stock variables in the configuration parser you must reference them as `{{server.build.env.ENVNAME}}` or just `{{env.ENVNAME}}`. Do not forget to to replace `ENVNAME` with the actual environment name you have setup.
+If you want to use egg non stock variables in the configuration parser you must reference them as 
+```text
+{{server.build.env.ENVNAME}}
+``` 
+or just 
+```text
+{{env.ENVNAME}}
+```
+Do not forget to to replace `ENVNAME` with the actual environment name you have setup.
 :::
 
 Once you have defined a parser, we then define a `find` block which tells the Daemon what specific elements to find

--- a/community/config/eggs/creating_a_custom_egg.md
+++ b/community/config/eggs/creating_a_custom_egg.md
@@ -32,7 +32,7 @@ our [Creating a Docker Image](/community/config/eggs/creating_a_custom_image.md)
 
 ## The Pterodactyl Install Procces
 
-:: warning
+::: warning
 Please be aware of how the pterodactyl install proces works!
 :::
 

--- a/community/config/eggs/creating_a_custom_image.md
+++ b/community/config/eggs/creating_a_custom_image.md
@@ -51,7 +51,7 @@ The next thing we do is install the dependencies we will need using Debian/Ubunt
 specific flags `-y` as the docker build is non interactive, as well as everything being contained in a
 single [`RUN`](https://docs.docker.com/engine/reference/builder/#run) block.
 
-## Files in the Docker image
+## Files In The Docker Image
 ::: warning
 Because the way that Pterodactyl works no files can be placed in the docker container in `/home/container`.
 :::

--- a/community/config/eggs/creating_a_custom_image.md
+++ b/community/config/eggs/creating_a_custom_image.md
@@ -13,7 +13,7 @@ reading up if this all looks foreign to you.
 The most important part of this process is to create the [`Dockerfile`](https://docs.docker.com/engine/reference/builder/)
 that will be used by the Daemon. Due to heavy restrictions on server containers, you must setup this file in a specific manner.
 
-In most images we try to use a [Debian based OS](https://www.debian.org) as much as possible for our images.
+We try to use a [Debian based OS](https://www.debian.org) as much as possible for our images
 
 ```bash
 FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:17-jdk-jammy
@@ -52,12 +52,12 @@ specific flags `-y` as the docker build is non interactive, as well as everythin
 single [`RUN`](https://docs.docker.com/engine/reference/builder/#run) block. 
 
 ::: warning
-The dependencie `iproute2` is required in every docker container to make the ip command work
+The dependency `iproute2` is required in every docker container to make the ip command work
 :::
 
 ## Files In The Docker Image
 ::: warning
-Because the way that Pterodactyl works no files can be placed in the docker container in `/home/container`.
+Because the way that Pterodactyl works, no files can be placed in the docker container in `/home/container`.
 :::
 
 All files must be downloaded with the egg install script, this means for example that you can not put your bot files or minecraft server jar can not be put in the image as you can with regular docker images

--- a/community/config/eggs/creating_a_custom_image.md
+++ b/community/config/eggs/creating_a_custom_image.md
@@ -68,7 +68,7 @@ Within this `RUN` block, you'll notice the `useradd` command.
 
 ```bash
  useradd -d /home/container -m container
- ```
+```
 
 ::: warning
 All Pterodactyl containers must have a user named `container`, and the user home **must** be `/home/container`.

--- a/community/config/eggs/creating_a_custom_image.md
+++ b/community/config/eggs/creating_a_custom_image.md
@@ -57,10 +57,10 @@ The dependency `iproute2` is required in every docker container to make the ip c
 
 ## Files In The Docker Image
 ::: warning
-Because the way that Pterodactyl works, no files can be placed in the docker container in `/home/container`.
+Because the way that Pterodactyl works, it is not possible to store any files within the Docker image at `/home/container`.
 :::
 
-All files must be downloaded with the egg install script, this means for example that you can not put your bot files or minecraft server jar can not be put in the image as you can with regular docker images
+All files must be downloaded with the egg install script, this means for example that you can not put your bot files or minecraft server jars in the Docker image as you can with regular docker images
 
 ## Creating a Container User
 

--- a/community/config/eggs/creating_a_custom_image.md
+++ b/community/config/eggs/creating_a_custom_image.md
@@ -3,7 +3,7 @@
 [[toc]]
 
 ::: warning
-This tutorial uses examples from our [`core:java`](https://github.com/pterodactyl/images/tree/java) docker image,
+This tutorial uses examples from our [`yolks:java_17`](https://github.com/pterodactyl/yolks/tree/master/java/17) docker image,
 which can be found on GitHub. This tutorial also assumes some knowledge of [Docker](https://docker.io/), we suggest
 reading up if this all looks foreign to you.
 :::
@@ -13,52 +13,58 @@ reading up if this all looks foreign to you.
 The most important part of this process is to create the [`Dockerfile`](https://docs.docker.com/engine/reference/builder/)
 that will be used by the Daemon. Due to heavy restrictions on server containers, you must setup this file in a specific manner.
 
-We try to make use of [Alpine Linux](https://alpinelinux.org) as much as possible for our images in order to keep their size down.
+In most images we try to use a [Debian based OS](https://www.debian.org) as much as possible for our images.
 
-```bash
-# ----------------------------------
-# Pterodactyl Core Dockerfile
-# Environment: Java
-# Minimum Panel Version: 0.6.0
-# ----------------------------------
-FROM openjdk:8-jdk-alpine
+```dockerfile
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:17-jdk-jammy
 
-MAINTAINER Pterodactyl Software, <support@pterodactyl.io>
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
-RUN apk add --no-cache --update curl ca-certificates openssl git tar bash sqlite fontconfig \
-    && adduser --disabled-password --home /home/container container
+LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.licenses=MIT
 
-USER container
-ENV  USER=container HOME=/home/container
+RUN 		apt-get update -y \
+ 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+ 			&& useradd -d /home/container -m container
 
-WORKDIR /home/container
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
 
-COPY ./entrypoint.sh /entrypoint.sh
-
-CMD ["/bin/bash", "/entrypoint.sh"]
+COPY        ./../entrypoint.sh /entrypoint.sh
+CMD         [ "/bin/bash", "/entrypoint.sh" ]
 ```
 
 Lets walk through the `Dockerfile` above. The first thing you'll notice is the [`FROM`](https://docs.docker.com/engine/reference/builder/#from) declaration.
 
 ```bash
-FROM openjdk:8-jdk-alpine
+FROM --platform=$TARGETOS/$TARGETARCH eclipse-temurin:17-jdk-jammy
 ```
 
-In this case, we are using [`openjdk:8-jdk-alpine`](https://github.com/docker-library/openjdk) which provides us with Java 8.
+The `--platform=$TARGETOS/$TARGETARCH` allows us to specify in the github workflow that we want to build for linux/amd64 and linux/arm64. See [Docker docs](https://docs.docker.com/engine/reference/builder/#from)
+
+In this case, we are using [`eclipse-temurin:17-jdk-jammy`](https://github.com/adoptium/containers/tree/main) which provides us with Java 17.
 
 ## Installing Dependencies
 
-The next thing we do is install the dependencies we will need using Alpine's package manager: `apk`. You'll notice some
-specific flags that keep the container small, including `--no-cache`, as well as everything being contained in a
+The next thing we do is install the dependencies we will need using Debian/Ubuntu's package manager: `apt`. You'll notice some
+specific flags `-y` as the docker build is non interactive, as well as everything being contained in a
 single [`RUN`](https://docs.docker.com/engine/reference/builder/#run) block.
+
+## Files in the Docker image
+::: warning
+Because the way that Pterodactyl works no files can be placed in the docker container in `/home/container`.
+:::
+
+All files must be downloaded with the egg install script, this means for example that you can not put your bot files or minecraft server jar can not be put in the image as you can with regular docker images
 
 ## Creating a Container User
 
 Within this `RUN` block, you'll notice the `useradd` command.
 
 ```bash
-adduser -D -h /home/container container
-```
+ useradd -d /home/container -m container
+ ```
 
 ::: warning
 All Pterodactyl containers must have a user named `container`, and the user home **must** be `/home/container`.
@@ -79,8 +85,8 @@ we define the command to be used when the container is started using [`CMD`](htt
 The `CMD` line should always point to the `entrypoint.sh` file.
 
 ```bash
-COPY ./entrypoint.sh /entrypoint.sh
-CMD ["/bin/bash", "/entrypoint.sh"]
+COPY        ./../entrypoint.sh /entrypoint.sh
+CMD         [ "/bin/bash", "/entrypoint.sh" ]
 ```
 
 ## Entrypoint Script
@@ -92,18 +98,31 @@ These entrypoint files are actually fairly abstracted, and the Daemon will pass 
 variable before processing it and then executing the command.
 
 ```bash
-#!/bin/bash
-cd /home/container
+# Default the TZ environment variable to UTC.
+TZ=${TZ:-UTC}
+export TZ
 
-# Output Current Java Version
-java -version ## only really needed to show what version is being used. Should be changed for different applications
+# Set environment variable that holds the Internal Docker IP
+INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
+export INTERNAL_IP
 
-# Replace Startup Variables
-MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
-echo ":/home/container$ ${MODIFIED_STARTUP}"
+# Switch to the container's working directory
+cd /home/container || exit 1
 
-# Run the Server
-${MODIFIED_STARTUP}
+# Print Java version
+printf "\033[1m\033[33mcontainer@pterodactyl~ \033[0mjava -version\n"
+java -version
+
+# Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
+# variable format of "${VARIABLE}" before evaluating the string and automatically
+# replacing the values.
+PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+
+# Display the command we're running in the output, and then execute it with the env
+# from the container itself.
+printf "\033[1m\033[33mcontainer@pterodactyl~ \033[0m%s\n" "$PARSED"
+# shellcheck disable=SC2086
+exec env ${PARSED}
 ```
 
 The second command, `cd /home/container`, simply ensures we are in the correct directory when running the rest of the
@@ -116,16 +135,15 @@ is parsing the environment `STARTUP` that is passed into the container by the Da
 looks something like the example below:
 
 ```bash
-STARTUP="java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}"
+STARTUP="java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}"
 ```
 
 ::: v-pre
-You'll notice some placeholders there, specifically `{{SERVER_MEMORY}}` and `{{SERVER_JARFILE}}`. These both refer to
+You'll notice some placeholders there, specifically `{{SERVER_JARFILE}}`. These refer to
 other environment variables being passed in, and they look something like the example below.
 :::
 
 ```bash
-SERVER_MEMORY=1024
 SERVER_JARFILE=server.jar
 ```
 
@@ -133,7 +151,7 @@ There are a host of different environment variables, and they change depending o
 configuration. However, that is not necessarily anything to worry about here.
 
 ```bash
-MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
+PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
 ```
 
 ::: v-pre
@@ -142,18 +160,18 @@ curly braces `{{EXAMPLE}}` with a matching environment variable (such as `EXAMPL
 :::
 
 ```bash
-java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}
+java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}"
 ```
 
 Becomes:
 
 ```bash
-java -Xms128M -Xmx1024M -jar server.jar
+java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar server.jar"
 ```
 
 ## Run the Command
 
-The last step is to run this modified startup command, which is done with the line `${MODIFIED_STARTUP}`.
+The last step is to run this modified startup command, which is done with the line `exec env ${PARSED}`.
 
 ### Note
 

--- a/community/config/eggs/creating_a_custom_image.md
+++ b/community/config/eggs/creating_a_custom_image.md
@@ -60,7 +60,7 @@ The dependency `iproute2` is required in every docker container to make the ip c
 Because the way that Pterodactyl works, it is not possible to store any files within the Docker image at `/home/container`.
 :::
 
-All files must be downloaded with the egg install script, this means for example that you can not put your bot files or minecraft server jars in the Docker image as you can with regular docker images
+All files must be downloaded with the egg install script, this means for example that you can not put your bot files or minecraft server jars in the Docker image as you can with regular docker images.
 
 ## Creating a Container User
 

--- a/community/config/eggs/creating_a_custom_image.md
+++ b/community/config/eggs/creating_a_custom_image.md
@@ -15,7 +15,7 @@ that will be used by the Daemon. Due to heavy restrictions on server containers,
 
 In most images we try to use a [Debian based OS](https://www.debian.org) as much as possible for our images.
 
-```dockerfile
+```bash
 FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:17-jdk-jammy
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
@@ -49,7 +49,11 @@ In this case, we are using [`eclipse-temurin:17-jdk-jammy`](https://github.com/a
 
 The next thing we do is install the dependencies we will need using Debian/Ubuntu's package manager: `apt`. You'll notice some
 specific flags `-y` as the docker build is non interactive, as well as everything being contained in a
-single [`RUN`](https://docs.docker.com/engine/reference/builder/#run) block.
+single [`RUN`](https://docs.docker.com/engine/reference/builder/#run) block. 
+
+::: warning
+The dependencie `iproute2` is required in every docker container to make the ip command work
+:::
 
 ## Files In The Docker Image
 ::: warning
@@ -125,7 +129,19 @@ printf "\033[1m\033[33mcontainer@pterodactyl~ \033[0m%s\n" "$PARSED"
 exec env ${PARSED}
 ```
 
-The second command, `cd /home/container`, simply ensures we are in the correct directory when running the rest of the
+First we set the timezone.
+```bash
+TZ=${TZ:-UTC}
+export TZ
+```
+
+Then we make the internal ip avaible in the docker container.
+```bash
+INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
+export INTERNAL_IP
+```
+
+The third command, `cd /home/container`, simply ensures we are in the correct directory when running the rest of the
 commands. We then follow that up with `java -version` to output this information to end-users, but that is not necessary.
 
 ## Modifying the Startup Command

--- a/community/config/eggs/creating_a_custom_image.md
+++ b/community/config/eggs/creating_a_custom_image.md
@@ -182,7 +182,7 @@ java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}
 Becomes:
 
 ```bash
-java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}} server.jar
+java -Xms128M -XX:MaxRAMPercentage=95.0 -jar server.jar
 ```
 
 ## Run the Command

--- a/community/config/eggs/creating_a_custom_image.md
+++ b/community/config/eggs/creating_a_custom_image.md
@@ -176,13 +176,13 @@ curly braces `{{EXAMPLE}}` with a matching environment variable (such as `EXAMPL
 :::
 
 ```bash
-java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}"
+java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}
 ```
 
 Becomes:
 
 ```bash
-java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar server.jar"
+java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar server.jar
 ```
 
 ## Run the Command

--- a/community/config/eggs/creating_a_custom_image.md
+++ b/community/config/eggs/creating_a_custom_image.md
@@ -151,7 +151,7 @@ is parsing the environment `STARTUP` that is passed into the container by the Da
 looks something like the example below:
 
 ```bash
-STARTUP="java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}"
+STARTUP="java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}"
 ```
 
 ::: v-pre
@@ -176,13 +176,13 @@ curly braces `{{EXAMPLE}}` with a matching environment variable (such as `EXAMPL
 :::
 
 ```bash
-java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}
+java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}
 ```
 
 Becomes:
 
 ```bash
-java -Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true -jar server.jar
+java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}} server.jar
 ```
 
 ## Run the Command


### PR DESCRIPTION
This PR is not perfect I do know that.

But changes in this pr
- mention how the pterodactyl install proces works (with the /mnt/server and /home/container)
- mention that no files can be in the docker container
- give an example on how to use the file parser
- mention how to use variables in the file parser
- mention how to set multiple done lines
- change the the java 17 example dockerfile and entrypoint 
- mention that we now mosty use debian based image and not alpine anymore
- mention the requirement of the package iproute2 for the ip command
