### PR TITLE
Add php-process to the package installs

### DIFF
--- a/community/installation-guides/panel/centos8.md
+++ b/community/installation-guides/panel/centos8.md
@@ -41,7 +41,7 @@ dnf module enable php:remi-8.0
 dnf update -y
 
 ## Install PHP 8.0
-dnf install -y php php-{common,fpm,cli,json,mysqlnd,gd,mbstring,pdo,zip,bcmath,dom,opcache}
+dnf install -y php php-{common,fpm,cli,json,mysqlnd,gd,mbstring,pdo,zip,bcmath,dom,opcache,process}
 ```
 
 ### If using Fedora Server 38 install PHP 8.1 and Dependencies from this section. If not, skip this section.


### PR DESCRIPTION
It seems in newer versions of EL distributions you need to install `php-process` in order to run `composer install --no-dev --optimize-autoloader`. Without the package you will receive the following:
```
 Problem 1
    - Root composer.json requires PHP extension ext-posix * but it is missing from your system. Install or enable PHP's posix extension.

```

This is just a simple PR to add `php-process` to the documentation.