### PR TITLE
Update comments for mail setup

### DIFF
--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -147,8 +147,9 @@ will cover setting up things such as sessions, caching, database credentials, an
 php artisan p:environment:setup
 php artisan p:environment:database
 
-# To use PHP's internal mail sending (not recommended), select "mail". To use a
-# custom SMTP server, select "smtp".
+# To use a custom SMTP server, select "smtp".
+# If you don't want to setup the panel mail skip this command.
+# You can always setup it up later if you changed your mind.
 php artisan p:environment:mail
 ```
 

--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -149,7 +149,7 @@ php artisan p:environment:database
 
 # To use a custom SMTP server, select "smtp".
 # If you don't want to setup the panel mail skip this command.
-# You can always setup it up later if you changed your mind.
+# You can always set it up later if you changed your mind.
 php artisan p:environment:mail
 ```
 


### PR DESCRIPTION
PHP's internal mail sending isn't available anymore. (see https://github.com/pterodactyl/panel/pull/4750)

Also added a note that you can skip the mail setup if you don't want to use the panel mails.