### PR TITLE
Correct caddy PHP_VALUE value as it doesn't support \n

### DIFF
--- a/.snippets/webservers/Caddyfile
+++ b/.snippets/webservers/Caddyfile
@@ -15,7 +15,8 @@
         root /var/www/pterodactyl/public
         index index.php
 
-        env PHP_VALUE "upload_max_filesize = 100M \n post_max_size = 100M"
+        env PHP_VALUE "upload_max_filesize = 100M
+        post_max_size = 100M"
         env HTTP_PROXY ""
         env HTTPS "on"
 

--- a/.snippets/webservers/Caddyfile-nossl
+++ b/.snippets/webservers/Caddyfile-nossl
@@ -15,7 +15,8 @@
         root /var/www/pterodactyl/public
         index index.php
 
-        env PHP_VALUE "upload_max_filesize = 100M \n post_max_size = 100M"
+        env PHP_VALUE "upload_max_filesize = 100M
+        post_max_size = 100M"
         env HTTP_PROXY ""
         # env HTTPS "on" # IMPORTANT: this is commented out, to disable HTTPS
 


### PR DESCRIPTION
Line breaks in environment variables in caddy fpm configs don't support the \n notation.

This was causing PHP to set `upload_max_filesize` to `100M \n post_max_size = 100M`.

This lead to `upload_max_filesize` being evaluated to an invalid value that causes file uploads (such as egg imports) to fail due to the size being above `upload_max_filesize`.

This PR replaces the \n with an actual newline.

I've confirmed this works in a fresh testing environment.