### PR TITLE
Remove some left over margins from the banner that was just removed

### DIFF
--- a/.vuepress/theme/Layout.vue
+++ b/.vuepress/theme/Layout.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div
-        class="theme-container mt-12"
+        class="theme-container"
         :class="pageClasses"
         @touchstart="onTouchStart"
         @touchend="onTouchEnd"

--- a/.vuepress/theme/styles/sidebar.css
+++ b/.vuepress/theme/styles/sidebar.css
@@ -6,7 +6,7 @@ $arrow-bg: #000;
     }
 
     @apply .fixed .left-0 .bottom-0 .bg-white .overflow-auto .border-r .border-grey-lighter .py-8;
-    top: calc(3rem + 56px);
+    top: 56px;
     width: 20rem;
     font-size: 15px;
 


### PR DESCRIPTION
This removes some of the left over margins from the banner that was just removed from the website.
Right now it's an empty space that's just pushing everything down.