### PR TITLE
Add noindex robots tag to old panel 0.7 and daemon 0.6 pages

### DIFF
--- a/daemon/0.6/configuration.md
+++ b/daemon/0.6/configuration.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Additional Configuration
 
 ::: danger This Software is Abandoned

--- a/daemon/0.6/debian_8_docker.md
+++ b/daemon/0.6/debian_8_docker.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Docker on Debian 8
 
 [[toc]]

--- a/daemon/0.6/installing.md
+++ b/daemon/0.6/installing.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Installation
 
 ::: danger This Software is Abandoned

--- a/daemon/0.6/kernel_modifications.md
+++ b/daemon/0.6/kernel_modifications.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Kernel Modifications
 
 [[toc]]

--- a/daemon/0.6/standalone_sftp.md
+++ b/daemon/0.6/standalone_sftp.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Standalone SFTP Server
 
 ::: danger This Software is Abandoned

--- a/daemon/0.6/upgrade/0.4_to_0.5.md
+++ b/daemon/0.6/upgrade/0.4_to_0.5.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Upgrading 0.4.X to 0.5.X
 
 ::: danger This Software is Abandoned

--- a/daemon/0.6/upgrade/0.5.md
+++ b/daemon/0.6/upgrade/0.5.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Upgrading 0.5 Series
 
 ::: danger This Software is Abandoned

--- a/daemon/0.6/upgrade/0.5_to_0.6.md
+++ b/daemon/0.6/upgrade/0.5_to_0.6.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Upgrading 0.5.X to 0.6.X
 
 ::: danger This Software is Abandoned

--- a/daemon/0.6/upgrade/0.6.md
+++ b/daemon/0.6/upgrade/0.6.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Upgrading 0.6 Series
 
 ::: danger This Software is Abandoned

--- a/daemon/0.6/upgrading.md
+++ b/daemon/0.6/upgrading.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Upgrading
 
 ::: danger This Software is Abandoned

--- a/panel/0.7/configuration.md
+++ b/panel/0.7/configuration.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Environment Configuration
 
 [[toc]]

--- a/panel/0.7/getting_started.md
+++ b/panel/0.7/getting_started.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Getting Started
 
 ::: danger This Version is End-of-Life

--- a/panel/0.7/troubleshooting.md
+++ b/panel/0.7/troubleshooting.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Troubleshooting
 
 [[toc]]

--- a/panel/0.7/upgrade/0.6_to_0.7.md
+++ b/panel/0.7/upgrade/0.6_to_0.7.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Upgrading 0.6 to 0.7
 
 ::: danger This Version is End-of-Life

--- a/panel/0.7/upgrade/0.7.md
+++ b/panel/0.7/upgrade/0.7.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Upgrading 0.7 Series
 
 ::: danger This Version is End-of-Life

--- a/panel/0.7/upgrading.md
+++ b/panel/0.7/upgrading.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Upgrading
 Upgrading the Panel is a relatively simple process. Below you will find a list of articles that will walk you through
 the upgrade process for each version of the software.

--- a/panel/0.7/webserver_configuration.md
+++ b/panel/0.7/webserver_configuration.md
@@ -1,3 +1,8 @@
+---
+meta:
+    - name: robots
+      content: noindex
+---
 # Webserver Configuration
 
 ::: danger This Version is End-of-Life


### PR DESCRIPTION
This is to prevent them from appearing on google search results.
They currently rank very high and are still confusing users despite the large warnings present on the pages.

Closes https://github.com/pterodactyl/documentation/issues/586