### PR TITLE
panel/1.0/troubleshooting: Add note about cert expiration

### DIFF
--- a/panel/1.0/troubleshooting.md
+++ b/panel/1.0/troubleshooting.md
@@ -70,6 +70,7 @@ and `2022` for SFTP traffic.
 https://domain.com:8080` on the Panel server and ensure that it can successfully connect to Wings.
 * Ensure that you are using the correct HTTP scheme for your Panel and Wings. If the Panel is running over HTTPS
   Wings will also need to be running on HTTPS.
+* If using HTTPS for Wings, make sure that the certificates have not expired.
 
 ### More Advanced Debugging Steps
 * Stop Wings and run `wings --debug` to see if there are any errors being output. If so, try resolving them manually,


### PR DESCRIPTION
Expired certificate can create an error that looks like a general communication error, since websocket or XHR requests just fail in very similar way like the service was not responding at all.

This could be a quite common case, especially if the certificate renewal (e.g. for Let's Encrypt) is not properly set up.