### PR TITLE
Update mounts.md

### DIFF
--- a/guides/mounts.md
+++ b/guides/mounts.md
@@ -19,10 +19,6 @@ You have to restart Wings to apply new changes to your Wings config.
 
 You have to configure mounts in admin Panel in order to use them with your servers. They consist of a source pad on the node and a target path where it will be mounted in the container.
 
-:::warning Path in the container
-Mounts cannot be mounted to or inside of `/home/container` or any subdirectory of it, nor can you cross-mount servers such as Server A's directory into Server B.
-:::
-
 ### Creating a Mount
 
 1. In the admin Panel go to **Mounts**.

--- a/guides/mounts.md
+++ b/guides/mounts.md
@@ -19,6 +19,11 @@ You have to restart Wings to apply new changes to your Wings config.
 
 You have to configure mounts in admin Panel in order to use them with your servers. They consist of a source pad on the node and a target path where it will be mounted in the container.
 
+:::info Path in the container
+Mounts can be mounted to or inside of `/home/container` or any subdirectory of it. You can cross-mount servers such as Server A's directory into Server B.
+Keep in mind that the folder you want to mount into needs to exist for the mount to work.
+:::
+
 ### Creating a Mount
 
 1. In the admin Panel go to **Mounts**.

--- a/guides/mounts.md
+++ b/guides/mounts.md
@@ -19,7 +19,7 @@ You have to restart Wings to apply new changes to your Wings config.
 
 You have to configure mounts in admin Panel in order to use them with your servers. They consist of a source pad on the node and a target path where it will be mounted in the container.
 
-:::info Path in the container
+::: tip Path in the container
 Mounts can be mounted to or inside of `/home/container` or any subdirectory of it. You can cross-mount servers such as Server A's directory into Server B.
 Keep in mind that the folder you want to mount into needs to exist for the mount to work.
 :::


### PR DESCRIPTION
Hi,

I removed an outdated note regarding not supported mounts. Old version of the documentation (https://github.com/pterodactyl/documentation/commit/e08c8f4cd0eb003ad5139d253a93e1547e06bfef#diff-381d4a108eb9141de271bb8caebfde8b61b25cc4122aab21eed43e7a2471d04d) clearly states that this is only due to a docker limitation/

That's no longer an issue and such mounts (at `/home/container`) work perfectly fine in Pterodactyl.