### PR TITLE
Update to centos8.md community guide

### DIFF
--- a/community/installation-guides/panel/centos8.md
+++ b/community/installation-guides/panel/centos8.md
@@ -34,7 +34,7 @@ sudo dnf module reset php
 sudo dnf module enable php:remi-8.3 -y
 
 # Install dependencies
-sudo dnf install -y php php-{common,cli,gd,mysql,mbstring,bcmath,xml,fpm,curl,zip} mariadb mariadb-server nginx redis zip unzip tar
+sudo dnf install -y php php-{common,cli,gd,mysql,mbstring,bcmath,xml,fpm,curl,zip,process} mariadb mariadb-server nginx redis zip unzip tar
 
 # Start and enable services
 sudo systemctl enable --now mariadb nginx redis


### PR DESCRIPTION
I added the php-process package containing the posix php module required by Composer to the dependencies list.

I was blocked because Composer was throwing
`Root composer.json requires PHP extension ext-posix * but it is missing from your system. Install or enable PHP's posix extension.`

The posix extension needed is part of the php-process package. Adding that package fixed the problem.