### PR TITLE
Update creating_ssl_certificates.md

### DIFF
--- a/tutorials/creating_ssl_certificates.md
+++ b/tutorials/creating_ssl_certificates.md
@@ -139,8 +139,7 @@ sudo mkdir -p /etc/letsencrypt/live/example.com
 After installing acme.sh and obtaining the CloudFlare API key, we need to then generate a certificate. First, input the CloudFlare API credentials.
 
 ```bash
-export CF_Key="Your_CloudFlare_API_Key"
-export CF_Email="Your_CloudFlare_Email"
+export CF_Token="Your_CloudFlare_API_Token"
 ```
 
 Then create the certificate. Since the API key is bound to the domain, Cloudflare should allow you to generate one.


### PR DESCRIPTION
Using the instructions above this code block, you create a Cloudflare API Token and not an API Key. The API token is the only variable you need to export before running the acme.sh command. You don't need to include an API Key or email and will work without it.