### PR TITLE
Update getting_started.md

### DIFF
--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -184,7 +184,7 @@ The last step in the installation process is to set the correct permissions on t
 use them correctly.
 
 ``` bash
-# If using NGINX or Apache (not on RHEL / Rocky Linux / AlmaLinux)
+# If using NGINX, Apache or Caddy (not on RHEL / Rocky Linux / AlmaLinux)
 chown -R www-data:www-data /var/www/pterodactyl/*
 
 # If using NGINX on RHEL / Rocky Linux / AlmaLinux


### PR DESCRIPTION
Add Caddy reference to the permissions part, otherwise the panel will return a 500 error if using Caddy as a webserver when trying to access it because permissions weren't applied.

Not sure if it is necessary on RHEL, Alma/Rocky as well as I mainly use Debian.