### PR TITLE
Update updating.md

### DIFF
--- a/panel/1.0/updating.md
+++ b/panel/1.0/updating.md
@@ -34,8 +34,8 @@ There are no 1.8.x, 1.9.x, or 1.10.x releases of Wings.
 - PHP `8.2`, or `8.3` (recommended)
 - Composer `2.X`
 
-**Before continuing**, please ensure that your system and web server configuration has been upgraded to at least PHP 8.2 by running `php -v` and Composer 2 by running `composer --version`. You
-should see an output similar to the result below. If you do not see at least PHP 8.2 and Composer 2, you will need to upgrade by following
+**Before continuing**, please ensure that your system and web server configuration has been upgraded to at least PHP 8.2 or 8.3 by running `php -v` and Composer 2 by running `composer --version`. You
+should see an output similar to the result below. If you do not see at least PHP 8.2 or 8,3 and Composer 2, you will need to upgrade by following
 our [PHP Upgrade Guide](/guides/php_upgrade.md) and return to this documentation afterward.
 
 ```shell


### PR DESCRIPTION
The documentation is slightly misleading in the supported php versions. It correctly states to use 8.2 or 8.3 at the top of the page, but scrolling down it says ''...running atleast 8.2'' indicating that 8.4 might also be supported (which it isn't)

Changed it to say ''...running atleast 8.2 or 8.3'' to avoid some confusion

Thanks to https://github.com/DataDropp for noticing it