### PR TITLE
feat: add tip about swap enabled by default on linux kernel v6.1 and newest

### DIFF
--- a/daemon/0.6/installing.md
+++ b/daemon/0.6/installing.md
@@ -93,6 +93,9 @@ systemctl enable docker
 ```
 
 #### Enabling Swap
+::: tip Recent Linux kernel
+Since the version 6.1 of the linux kernel, swap is enabled by default. If you are running a kernel version 6.1 or newer, you can skip this step. To check your kernel version, run `uname -r`.
+:::
 On most systems, docker will be unable to setup swap space, you can check if this is the case by running `docker info`.
 If it outputs `WARNING: No swap limit support` near the bottom, this is the case. Enabling swap is completely optional,
 but we recommended doing it if you will be hosting for others, and to prevent OOM errors.

--- a/wings/1.0/installing.md
+++ b/wings/1.0/installing.md
@@ -75,7 +75,9 @@ sudo systemctl enable --now docker
 ```
 
 #### Enabling Swap
-
+::: tip Recent Linux kernel
+Since the version 6.1 of the linux kernel, swap is enabled by default. If you are running a kernel version 6.1 or newer, you can skip this step. To check your kernel version, run `uname -r`.
+:::
 On most systems, Docker will be unable to setup swap space by default. You can confirm this by running `docker info` and looking for the output of `WARNING: No swap limit support` near the bottom.
 
 Enabling swap is entirely optional, but we recommended doing it if you will be hosting for others and to prevent OOM errors.


### PR DESCRIPTION
this is just a tip as danny6167 pointed, not all distribution use a 6.1 or newest kernel