### PR TITLE
Update dependency install with links to community guides to alt. distros

### DIFF
--- a/panel/1.0/getting_started.md
+++ b/panel/1.0/getting_started.md
@@ -50,6 +50,9 @@ this software on an OpenVZ based system you will &mdash; most likely &mdash; not
 The commands below are simply an example of how you might install these dependencies. Please consult with your
 operating system's package manager to determine the correct packages to install.
 
+::: tip Other distros
+There are community made guides to install dependencies for [Debian](https://pterodactyl.io/community/installation-guides/panel/debian.html), [CentOS 7](https://pterodactyl.io/community/installation-guides/panel/centos7.html) and [Enterprise Linux 8 (CentOS 8, Rocky Linux 8, AlmaLinux 8) and Fedora Server 40](https://pterodactyl.io/community/installation-guides/panel/centos8.html) available too.
+
 ``` bash
 # Add "add-apt-repository" command
 apt -y install software-properties-common curl apt-transport-https ca-certificates gnupg


### PR DESCRIPTION
Add links to the install dependency guides made for Debian, CentOS  7/8 - These are helpful but not linked in the main docs which only work for Ubuntu.

This does also specifically mention that they are "community guides", but still - Linking them here would do more good or point people in the right direction atleast, as some may blindly follow the steps for ubuntu on another distro.