### PR TITLE
Correct php8.3-pdo to php8.3-common

### DIFF
--- a/guides/php_upgrade.md
+++ b/guides/php_upgrade.md
@@ -21,7 +21,7 @@ may have slightly different requirements for how this command is formatted.
 # Add additional repository for PHP
 add-apt-repository -y ppa:ondrej/php
 apt -y update
-apt -y install php8.3 php8.3-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip}
+apt -y install php8.3 php8.3-{cli,gd,mysql,common,mbstring,tokenizer,bcmath,xml,fpm,curl,zip}
 ```
 
 ## Update Composer


### PR DESCRIPTION
php8.3-pdo automatically resolves to php8.3-common when installed - propose bringing the documentation in line to help when troubleshooting