### PR TITLE
Added two "::: warning"s for two problems that I encountered while installing + One other minor edit

### DIFF
--- a/community/installation-guides/panel/centos8.md
+++ b/community/installation-guides/panel/centos8.md
@@ -79,6 +79,6 @@ sudo systemctl enable --now php-fpm
 Excellent, we now have all of the required dependencies installed and configured. From here, follow the [official Panel installation documentation](/panel/1.0/getting_started.md#download-files).
 
 
-::: warn
+::: warning
 You will need to change the fastcgi_pass path in the Nginx configuration to `/var/run/php-fpm/pterodactyl.sock`
 :::

--- a/community/installation-guides/panel/centos8.md
+++ b/community/installation-guides/panel/centos8.md
@@ -79,6 +79,6 @@ sudo systemctl enable --now php-fpm
 Excellent, we now have all of the required dependencies installed and configured. From here, follow the [official Panel installation documentation](/panel/1.0/getting_started.md#download-files).
 
 
-::: tip
+::: warn
 You will need to change the fastcgi_pass path in the Nginx configuration to `/var/run/php-fpm/pterodactyl.sock`
 :::

--- a/community/installation-guides/panel/centos8.md
+++ b/community/installation-guides/panel/centos8.md
@@ -82,3 +82,20 @@ Excellent, we now have all of the required dependencies installed and configured
 ::: warning
 You will need to change the fastcgi_pass path in the Nginx configuration to `/var/run/php-fpm/pterodactyl.sock`
 :::
+
+::: warning
+If you complete the [official Panel installation documentation](/panel/1.0/getting_started.md#download-files) but get a HTTP 500 error code and "Permission Denied" errors in `/var/log/nginx/pterodactyl.app-error.log`, you may need to run the following commands: 
+
+``` bash
+sudo chcon -R -t httpd_sys_rw_content_t storage
+sudo chcon -R -t httpd_sys_rw_content_t bootstrap/cache
+```
+:::
+
+::: warning
+If you get "Permission denied \[tcp://127.0.0.1:6379\]" in your laravel log (`/var/www/pterodactyl/storage/logs/laravel-TODAYS-DATE.log`), you may need to run the following commands: 
+
+``` bash
+sudo setsebool httpd_can_network_connect=1
+```
+:::


### PR DESCRIPTION
I encountered some problems while installing Pterodactyl Panel on Fedora Server 41, so I figured I'd add the solutions I found here. 
I'm quite sure that these apply to more RHEL/Fedora-based distros, but I'm afraid I haven't tested installing the Panel on other distros so I don't know. 

I also changed the preexisting "::: tip" to a "::: warning", because I think that the information in that "::: tip" block sounds much more important than your average (potentially optional) tip. 