### PR TITLE
Small oversight in Upgrade Wings, tar needs --overwrite to overwrite existing files

### DIFF
--- a/panel/1.0/updating.md
+++ b/panel/1.0/updating.md
@@ -84,7 +84,7 @@ the release archive for the most recent version of Pterodactyl, save it in the c
 unpack the archive into your current folder.
 
 ```bash
-curl -L https://github.com/pterodactyl/panel/releases/latest/download/panel.tar.gz | tar -xzv
+curl -L https://github.com/pterodactyl/panel/releases/latest/download/panel.tar.gz | tar -xzv --overwrite
 ```
 
 Once all of the files are downloaded we need to set the correct permissions on the cache and storage directories to avoid


### PR DESCRIPTION
Updated the tar command in the upgrade wings section, to overwrite existing files. Without overwrite the tar command fails.

tested on Ubuntu 24,04.03 LTS